### PR TITLE
feat: comprehensive SEO + GEO overhaul

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,30 +3,54 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Ninad Malvankar — Senior Principal Engineer</title>
-  <meta name="description" content="Ninad Malvankar — Senior Principal Engineer at Upstox. Specialising in cloud infrastructure, fintech platforms, and engineering leadership." />
+  <title>Ninad Malvankar — Senior Principal Engineer at Upstox</title>
+  <meta name="description" content="Ninad Malvankar is a Senior Principal Engineer at Upstox, India's leading fintech platform. 12+ years building cloud infrastructure, fintech systems, and engineering teams at scale. AWS Certified. M.S. Computer Science. Based in Mumbai, India." />
   <meta name="author" content="Ninad Malvankar" />
-  <meta name="robots" content="index, follow" />
-  <meta name="keywords" content="Ninad Malvankar, Senior Principal Engineer, Upstox, cloud infrastructure, fintech, engineering leadership, AWS, React, Node.js, microservices, system design" />
-  <link rel="canonical" href="https://elninad.github.io/" />
+  <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1" />
+  <meta name="keywords" content="Ninad Malvankar, Senior Principal Engineer, Upstox, cloud infrastructure, fintech engineering, engineering leadership, AWS, AWS Certified, React, Angular, Node.js, TypeScript, microservices, system design, DevOps, platform engineering, cloud architecture, Mumbai India, principal engineer India, fintech platform, AWS CloudFront, AWS WAF, distributed systems, software architect, elninad" />
+  <link rel="canonical" href="https://ninadmalvankar.com/" />
+  <link rel="sitemap" type="application/xml" href="/sitemap.xml" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="me" href="https://www.linkedin.com/in/ninadmalvankar/" />
+  <link rel="me" href="https://github.com/elninad" />
+  <link rel="me" href="https://medium.com/@ninad.malvankar23" />
+  <link rel="me" href="https://x.com/el_ninad" />
+  <link rel="author" href="https://www.linkedin.com/in/ninadmalvankar/" />
+  <meta name="geo.region" content="IN-MH" />
+  <meta name="geo.placename" content="Mumbai, Maharashtra, India" />
+  <meta name="geo.position" content="19.0760;72.8777" />
+  <meta name="ICBM" content="19.0760, 72.8777" />
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://elninad.github.io/" />
-  <meta property="og:title" content="Ninad Malvankar — Senior Principal Engineer" />
-  <meta property="og:description" content="Ninad Malvankar is a Senior Principal Engineer at Upstox with 12+ years of experience in cloud infrastructure, fintech platforms, and engineering leadership." />
+  <meta property="og:url" content="https://ninadmalvankar.com/" />
+  <meta property="og:title" content="Ninad Malvankar — Senior Principal Engineer at Upstox" />
+  <meta property="og:description" content="Senior Principal Engineer at Upstox — India's leading fintech platform. 12+ years in cloud infrastructure, system design, and engineering leadership. AWS Certified. Mumbai, India." />
+  <meta property="og:image" content="https://ninadmalvankar.com/og-image.svg" />
+  <meta property="og:image:width" content="1200" />
+  <meta property="og:image:height" content="630" />
+  <meta property="og:image:alt" content="Ninad Malvankar — Senior Principal Engineer at Upstox" />
   <meta property="og:site_name" content="Ninad Malvankar" />
   <meta property="og:locale" content="en_US" />
+  <meta property="profile:first_name" content="Ninad" />
+  <meta property="profile:last_name" content="Malvankar" />
+  <meta property="profile:username" content="elninad" />
 
   <!-- Twitter Card -->
-  <meta name="twitter:card" content="summary" />
-  <meta name="twitter:url" content="https://elninad.github.io/" />
-  <meta name="twitter:title" content="Ninad Malvankar — Senior Principal Engineer" />
-  <meta name="twitter:description" content="Ninad Malvankar is a Senior Principal Engineer at Upstox with 12+ years of experience in cloud infrastructure, fintech platforms, and engineering leadership." />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:url" content="https://ninadmalvankar.com/" />
+  <meta name="twitter:title" content="Ninad Malvankar — Senior Principal Engineer at Upstox" />
+  <meta name="twitter:description" content="Senior Principal Engineer at Upstox — 12+ years in cloud infrastructure, fintech platforms, and engineering leadership. AWS Certified. Based in Mumbai, India." />
+  <meta name="twitter:image" content="https://ninadmalvankar.com/og-image.svg" />
+  <meta name="twitter:image:alt" content="Ninad Malvankar — Senior Principal Engineer at Upstox" />
   <meta name="twitter:creator" content="@el_ninad" />
+  <meta name="twitter:site" content="@el_ninad" />
 
-  <!-- Theme -->
+  <!-- Theme & App -->
   <meta name="theme-color" content="#6366f1" />
+  <meta name="application-name" content="Ninad Malvankar" />
+  <meta name="format-detection" content="telephone=no" />
+  <meta name="color-scheme" content="dark" />
 
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet" />
@@ -590,7 +614,7 @@
     "@graph": [
       {
         "@type": "Person",
-        "@id": "https://elninad.github.io/#person",
+        "@id": "https://ninadmalvankar.com/#person",
         "name": "Ninad Malvankar",
         "givenName": "Ninad",
         "familyName": "Malvankar",
@@ -599,9 +623,29 @@
           "@type": "Organization",
           "name": "Upstox",
           "url": "https://upstox.com",
+          "description": "India's leading discount brokerage and fintech platform",
           "industry": "FinTech"
         },
-        "url": "https://elninad.github.io/",
+        "url": "https://ninadmalvankar.com/",
+        "mainEntityOfPage": {
+          "@id": "https://ninadmalvankar.com/#webpage"
+        },
+        "image": {
+          "@type": "ImageObject",
+          "url": "https://ninadmalvankar.com/og-image.svg",
+          "width": 1200,
+          "height": 630
+        },
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Mumbai",
+          "addressRegion": "Maharashtra",
+          "addressCountry": "IN"
+        },
+        "nationality": {
+          "@type": "Country",
+          "name": "India"
+        },
         "sameAs": [
           "https://www.linkedin.com/in/ninadmalvankar/",
           "https://github.com/elninad",
@@ -624,19 +668,43 @@
         "knowsAbout": [
           "Cloud Infrastructure",
           "AWS",
+          "AWS CloudFront",
+          "AWS WAF",
+          "Amazon S3",
           "FinTech",
           "Engineering Leadership",
           "System Design",
-          "Microservices",
+          "Microservices Architecture",
           "DevOps",
           "React",
+          "Angular",
           "Node.js",
           "TypeScript",
+          "JavaScript",
+          ".NET",
+          "C#",
           "Docker",
-          "CI/CD",
+          "CI/CD Pipelines",
           "Cloudflare",
-          "Software Architecture"
+          "Software Architecture",
+          "Platform Engineering",
+          "Technical Strategy",
+          "Distributed Systems",
+          "Mentorship",
+          "Nexus Repository Manager",
+          "Express.js"
         ],
+        "knowsLanguage": ["en"],
+        "publishingPrinciples": "https://medium.com/@ninad.malvankar23",
+        "potentialAction": {
+          "@type": "CommunicateAction",
+          "target": {
+            "@type": "EntryPoint",
+            "urlTemplate": "https://www.linkedin.com/in/ninadmalvankar/",
+            "actionPlatform": ["DesktopWebPlatform", "MobileWebPlatform"]
+          },
+          "description": "Connect with Ninad Malvankar on LinkedIn"
+        },
         "hasCredential": [
           {
             "@type": "EducationalOccupationalCredential",
@@ -645,7 +713,8 @@
             "dateCreated": "2023",
             "recognizedBy": {
               "@type": "Organization",
-              "name": "Amazon Web Services"
+              "name": "Amazon Web Services",
+              "sameAs": "https://aws.amazon.com"
             }
           },
           {
@@ -655,7 +724,8 @@
             "dateCreated": "2013",
             "recognizedBy": {
               "@type": "CollegeOrUniversity",
-              "name": "University of Texas at Arlington"
+              "name": "University of Texas at Arlington",
+              "sameAs": "https://www.uta.edu/"
             }
           },
           {
@@ -665,31 +735,131 @@
             "dateCreated": "2011",
             "recognizedBy": {
               "@type": "CollegeOrUniversity",
-              "name": "University of Mumbai"
+              "name": "University of Mumbai",
+              "sameAs": "https://mu.ac.in/"
+            }
+          },
+          {
+            "@type": "EducationalOccupationalCredential",
+            "name": "Verified International Academic Qualifications",
+            "credentialCategory": "certification",
+            "dateCreated": "2023",
+            "recognizedBy": {
+              "@type": "Organization",
+              "name": "World Education Services (WES)"
             }
           }
         ],
-        "description": "Senior Principal Engineer at Upstox with 12+ years of experience building cloud infrastructure and fintech platforms. Expert in engineering leadership, system design, AWS, microservices, and DevOps. Previously worked at enSYNC Corporation and Swift Pace Solutions (Disney project). M.S. Computer Science from University of Texas at Arlington."
+        "description": "Ninad Malvankar is a Senior Principal Engineer at Upstox, India's leading discount brokerage and fintech platform. With 12+ years of experience, he specialises in cloud infrastructure on AWS (CloudFront, WAF, S3), fintech platform engineering, engineering leadership, system design, and microservices architecture. He is AWS Certified, holds an M.S. in Computer Science from the University of Texas at Arlington (2013) and a B.E. in Computer Engineering from the University of Mumbai (2011). Previously Programmer Analyst at Swift Pace Solutions (Walt Disney World project) and Software Engineer at enSYNC Corporation. Based in Mumbai, India."
+      },
+      {
+        "@type": "ProfilePage",
+        "@id": "https://ninadmalvankar.com/#webpage",
+        "url": "https://ninadmalvankar.com/",
+        "name": "Ninad Malvankar — Senior Principal Engineer at Upstox",
+        "description": "Personal portfolio of Ninad Malvankar, Senior Principal Engineer at Upstox. Showcasing career timeline, technical skills, certifications, and engineering writing.",
+        "mainEntity": {
+          "@id": "https://ninadmalvankar.com/#person"
+        },
+        "author": {
+          "@id": "https://ninadmalvankar.com/#person"
+        },
+        "isPartOf": {
+          "@id": "https://ninadmalvankar.com/#website"
+        },
+        "inLanguage": "en-US",
+        "dateModified": "2026-04-21",
+        "breadcrumb": {
+          "@type": "BreadcrumbList",
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "Ninad Malvankar",
+              "item": "https://ninadmalvankar.com/"
+            }
+          ]
+        }
       },
       {
         "@type": "WebSite",
-        "@id": "https://elninad.github.io/#website",
-        "url": "https://elninad.github.io/",
+        "@id": "https://ninadmalvankar.com/#website",
+        "url": "https://ninadmalvankar.com/",
         "name": "Ninad Malvankar — Portfolio",
         "description": "Personal portfolio of Ninad Malvankar, Senior Principal Engineer at Upstox, showcasing career timeline, technical skills, certifications, and engineering writing.",
         "author": {
-          "@id": "https://elninad.github.io/#person"
+          "@id": "https://ninadmalvankar.com/#person"
+        },
+        "creator": {
+          "@id": "https://ninadmalvankar.com/#person"
+        },
+        "inLanguage": "en-US",
+        "isAccessibleForFree": true
+      },
+      {
+        "@type": "Article",
+        "@id": "https://medium.com/@ninad.malvankar23/the-role-of-a-principal-engineer-leadership-without-authority-c4f7b6dc1ccf",
+        "headline": "The Role of a Principal Engineer — Leadership Without Authority",
+        "url": "https://medium.com/@ninad.malvankar23/the-role-of-a-principal-engineer-leadership-without-authority-c4f7b6dc1ccf",
+        "description": "An exploration of how Principal Engineers lead through influence, expertise, and trust rather than formal authority — driving clarity and moving teams faster, safer, and smarter.",
+        "articleSection": "Engineering Leadership",
+        "keywords": ["Principal Engineer", "Engineering Leadership", "Technical Influence", "Leadership Without Authority"],
+        "author": {
+          "@id": "https://ninadmalvankar.com/#person"
+        },
+        "publisher": {
+          "@type": "Organization",
+          "name": "Medium",
+          "url": "https://medium.com"
         },
         "inLanguage": "en-US"
       },
       {
         "@type": "Article",
-        "@id": "https://medium.com/@ninad.malvankar23/the-role-of-a-principal-engineer-leadership-without-authority-c4f7b6dc1ccf#article",
-        "headline": "The Role of a Principal Engineer — Leadership Without Authority",
-        "url": "https://medium.com/@ninad.malvankar23/the-role-of-a-principal-engineer-leadership-without-authority-c4f7b6dc1ccf",
-        "description": "An exploration of how Principal Engineers lead through influence, expertise, and trust rather than formal authority.",
+        "@id": "https://medium.com/@ninad.malvankar23/what-happens-when-you-outgrow-mentorship-lessons-from-a-principal-engineer-0f7bc0672aa7",
+        "headline": "What Happens When You Outgrow Mentorship? Lessons from a Principal Engineer",
+        "url": "https://medium.com/@ninad.malvankar23/what-happens-when-you-outgrow-mentorship-lessons-from-a-principal-engineer-0f7bc0672aa7",
+        "description": "How to continue growing as a principal engineer after formal mentorship ends — using personal retrospectives, self-built feedback loops, and treating yourself like a system.",
+        "articleSection": "Engineering Leadership",
+        "keywords": ["Principal Engineer", "Mentorship", "Career Growth", "Self-improvement", "Engineering Career"],
         "author": {
-          "@id": "https://elninad.github.io/#person"
+          "@id": "https://ninadmalvankar.com/#person"
+        },
+        "publisher": {
+          "@type": "Organization",
+          "name": "Medium",
+          "url": "https://medium.com"
+        },
+        "inLanguage": "en-US"
+      },
+      {
+        "@type": "Article",
+        "@id": "https://medium.com/@ninad.malvankar23/spring-security-meets-java-21-a-closer-look-at-firewall-controls-db4a9fc1d897",
+        "headline": "Spring Security Meets Java 21: A Closer Look at Firewall Controls",
+        "url": "https://medium.com/@ninad.malvankar23/spring-security-meets-java-21-a-closer-look-at-firewall-controls-db4a9fc1d897",
+        "description": "How Spring Security's firewall controls behave in Java 21 environments — security implications backend engineers overlook when upgrading.",
+        "articleSection": "Backend Engineering",
+        "keywords": ["Spring Security", "Java 21", "Firewall Controls", "Backend Security", "Spring Framework"],
+        "author": {
+          "@id": "https://ninadmalvankar.com/#person"
+        },
+        "publisher": {
+          "@type": "Organization",
+          "name": "Medium",
+          "url": "https://medium.com"
+        },
+        "inLanguage": "en-US"
+      },
+      {
+        "@type": "Article",
+        "@id": "https://medium.com/@ninad.malvankar23/how-a-bad-webpack-config-can-silently-destroy-frontend-performance-0622df39323f",
+        "headline": "How a Bad Webpack Config Can Silently Destroy Frontend Performance",
+        "url": "https://medium.com/@ninad.malvankar23/how-a-bad-webpack-config-can-silently-destroy-frontend-performance-0622df39323f",
+        "description": "How misconfigured webpack bundles silently degrade frontend performance without obvious errors — what to look for and how to fix it.",
+        "articleSection": "Frontend Engineering",
+        "keywords": ["Webpack", "Frontend Performance", "JavaScript Bundling", "Build Configuration", "Performance Optimization"],
+        "author": {
+          "@id": "https://ninadmalvankar.com/#person"
         },
         "publisher": {
           "@type": "Organization",
@@ -700,14 +870,14 @@
       },
       {
         "@type": "FAQPage",
-        "@id": "https://elninad.github.io/#faq",
+        "@id": "https://ninadmalvankar.com/#faq",
         "mainEntity": [
           {
             "@type": "Question",
             "name": "Who is Ninad Malvankar?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "Ninad Malvankar is a Senior Principal Engineer at Upstox, a leading Indian fintech platform. With 12+ years of experience, he specialises in cloud infrastructure (AWS), engineering leadership, system design, and microservices. He holds an M.S. in Computer Science from the University of Texas at Arlington and is AWS Certified."
+              "text": "Ninad Malvankar is a Senior Principal Engineer at Upstox, India's leading discount brokerage and fintech platform. With 12+ years of experience, he specialises in cloud infrastructure (AWS), engineering leadership, system design, and microservices. He holds an M.S. in Computer Science from the University of Texas at Arlington and is AWS Certified. He is based in Mumbai, India."
             }
           },
           {
@@ -715,7 +885,7 @@
             "name": "What does Ninad Malvankar specialise in?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "Ninad specialises in cloud architecture (AWS), fintech platform engineering, engineering leadership, system design, DevOps, microservices, and full-stack development using React, Node.js, TypeScript, and .NET/C#."
+              "text": "Ninad specialises in cloud architecture (AWS CloudFront, WAF, S3), fintech platform engineering, engineering leadership, system design, DevOps, microservices, and full-stack development using React, Angular, Node.js, TypeScript, and .NET/C#. He is particularly experienced in building and scaling high-availability platforms in the Indian fintech and brokerage sector."
             }
           },
           {
@@ -723,7 +893,47 @@
             "name": "Where has Ninad Malvankar worked?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "Ninad has worked at Upstox (2018–present, currently as Senior Principal Engineer), Swift Pace Solutions Inc on a Disney project (2017–2018), enSYNC Corporation (2013–2017), and the University of Texas at Arlington (2012–2013). He has been at Upstox since 2018, progressing from Technology Lead to Principal Engineer to Senior Principal Engineer."
+              "text": "Ninad has worked at Upstox (2018–present, currently Senior Principal Engineer), Swift Pace Solutions Inc on a Walt Disney World project (2017–2018), enSYNC Corporation (2013–2017), and the University of Texas at Arlington as Web Developer (2012–2013). At Upstox, he progressed from Technology Lead (2018–2021) to Principal Engineer (2021–2022) to Senior Principal Engineer (2022–present)."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What is Ninad Malvankar's educational background?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Ninad Malvankar holds an M.S. in Computer Science from the University of Texas at Arlington (2011–2013), focusing on distributed systems and web technologies, and a B.E. in Computer Engineering from the University of Mumbai (2007–2011). He is also an AWS Certified Cloud Practitioner (2023) and his academic qualifications are verified by World Education Services (WES)."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What is Ninad Malvankar's current role at Upstox?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Ninad Malvankar is a Senior Principal Engineer at Upstox, India's top discount brokerage and fintech platform. He leads cross-functional engineering, drives platform reliability and developer productivity, shapes technical strategy, and mentors engineers across the organization. He joined Upstox in July 2018 as Technology Lead and has progressively taken on more senior roles."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What AWS services does Ninad Malvankar work with?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Ninad works extensively with AWS CloudFront for CDN and caching, AWS WAF for web application firewall ACL protection against web exploits, Amazon S3, and related AWS infrastructure services. He configured CloudFront distributions and WAF ACLs for Upstox's high-traffic fintech platform. He holds an AWS Certified Cloud Practitioner certification."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What articles has Ninad Malvankar written?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Ninad Malvankar publishes on Medium about engineering leadership and software architecture. His articles include: 'The Role of a Principal Engineer — Leadership Without Authority', 'What Happens When You Outgrow Mentorship? Lessons from a Principal Engineer', 'Spring Security Meets Java 21: A Closer Look at Firewall Controls', and 'How a Bad Webpack Config Can Silently Destroy Frontend Performance'."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Where can I contact or follow Ninad Malvankar?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Ninad Malvankar can be found on LinkedIn (linkedin.com/in/ninadmalvankar/), GitHub (github.com/elninad), Medium (medium.com/@ninad.malvankar23) where he writes about engineering leadership and system design, and on X/Twitter (@el_ninad). He also runs a YouTube channel (@el_nino) focused on cars and motorsport."
             }
           }
         ]

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,49 @@
+# Ninad Malvankar — Senior Principal Engineer
+
+> Ninad Malvankar is a Senior Principal Engineer at Upstox, India's leading discount brokerage and fintech platform. He has 12+ years of experience in cloud infrastructure (AWS), fintech platform engineering, engineering leadership, system design, microservices, and full-stack development. Based in Mumbai, India.
+
+## About
+
+Ninad Malvankar (GitHub: elninad) specialises in:
+- AWS cloud architecture (CloudFront, WAF, S3)
+- Fintech platform engineering and high-availability systems
+- Engineering leadership (mentoring, technical strategy, cross-functional teams)
+- System design and microservices architecture
+- Full-stack development: React, Angular, Node.js, TypeScript, .NET/C#
+- DevOps: Docker, CI/CD pipelines, Nexus Repository Manager, Cloudflare
+
+Education:
+- M.S. Computer Science — University of Texas at Arlington (2011–2013)
+- B.E. Computer Engineering — University of Mumbai (2007–2011)
+
+Certifications:
+- AWS Certified Cloud Practitioner (Amazon Web Services, 2023)
+- Verified International Academic Qualifications (World Education Services, 2023)
+
+## Career Timeline
+
+- Senior Principal Engineer — Upstox (2022–present)
+- Principal Engineer — Upstox (2021–2022)
+- Technology Lead — Upstox (2018–2021)
+- Programmer Analyst — Swift Pace Solutions / Walt Disney World project (Mar 2017–Feb 2018)
+- Software Engineer — enSYNC Corporation (Aug 2013–Jan 2017)
+- Web Developer — University of Texas at Arlington (Mar 2012–May 2013)
+
+## Writing (Published on Medium)
+
+- [The Role of a Principal Engineer — Leadership Without Authority](https://medium.com/@ninad.malvankar23/the-role-of-a-principal-engineer-leadership-without-authority-c4f7b6dc1ccf): How Principal Engineers lead through influence, expertise, and trust rather than formal authority.
+- [What Happens When You Outgrow Mentorship? Lessons from a Principal Engineer](https://medium.com/@ninad.malvankar23/what-happens-when-you-outgrow-mentorship-lessons-from-a-principal-engineer-0f7bc0672aa7): Growing beyond formal mentorship using personal retrospectives and self-built feedback loops.
+- [Spring Security Meets Java 21: A Closer Look at Firewall Controls](https://medium.com/@ninad.malvankar23/spring-security-meets-java-21-a-closer-look-at-firewall-controls-db4a9fc1d897): Security implications of Spring Security's firewall controls in Java 21 environments.
+- [How a Bad Webpack Config Can Silently Destroy Frontend Performance](https://medium.com/@ninad.malvankar23/how-a-bad-webpack-config-can-silently-destroy-frontend-performance-0622df39323f): How webpack configuration mistakes can silently degrade frontend performance.
+
+## Social Profiles
+
+- LinkedIn: https://www.linkedin.com/in/ninadmalvankar/
+- GitHub: https://github.com/elninad
+- Medium: https://medium.com/@ninad.malvankar23
+- X/Twitter: https://x.com/el_ninad
+- YouTube: https://youtube.com/@el_nino
+
+## Portfolio
+
+- Personal site: https://ninadmalvankar.com/

--- a/og-image.svg
+++ b/og-image.svg
@@ -1,0 +1,79 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <radialGradient id="bg1" cx="75%" cy="35%" r="55%">
+      <stop offset="0%" stop-color="#6366f1" stop-opacity="0.35"/>
+      <stop offset="100%" stop-color="#060b18" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="bg2" cx="15%" cy="80%" r="45%">
+      <stop offset="0%" stop-color="#8b5cf6" stop-opacity="0.2"/>
+      <stop offset="100%" stop-color="#060b18" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="nameGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#e2e8f0"/>
+      <stop offset="50%" stop-color="#818cf8"/>
+      <stop offset="100%" stop-color="#a78bfa"/>
+    </linearGradient>
+    <linearGradient id="roleGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#f59e0b"/>
+      <stop offset="100%" stop-color="#fb923c"/>
+    </linearGradient>
+    <linearGradient id="barGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#6366f1"/>
+      <stop offset="100%" stop-color="#a78bfa"/>
+    </linearGradient>
+    <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+      <path d="M 60 0 L 0 0 0 60" fill="none" stroke="rgba(99,102,241,0.06)" stroke-width="1"/>
+    </pattern>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="#060b18"/>
+  <rect width="1200" height="630" fill="url(#bg1)"/>
+  <rect width="1200" height="630" fill="url(#bg2)"/>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+
+  <!-- Left accent bar -->
+  <rect x="80" y="140" width="4" height="350" rx="2" fill="url(#barGrad)"/>
+
+  <!-- Badge -->
+  <rect x="108" y="148" width="220" height="36" rx="18" fill="rgba(99,102,241,0.15)" stroke="rgba(99,102,241,0.3)" stroke-width="1"/>
+  <circle cx="130" cy="166" r="5" fill="#6366f1"/>
+  <text x="145" y="171" font-family="Inter,-apple-system,sans-serif" font-size="14" font-weight="600" fill="#6366f1" letter-spacing="0.08em">SENIOR PRINCIPAL ENGINEER</text>
+
+  <!-- Name -->
+  <text x="108" y="280" font-family="Inter,-apple-system,sans-serif" font-size="76" font-weight="900" letter-spacing="-2" fill="url(#nameGrad)">Ninad Malvankar</text>
+
+  <!-- Role line -->
+  <text x="108" y="340" font-family="Inter,-apple-system,sans-serif" font-size="32" font-weight="600" fill="url(#roleGrad)">@ Upstox · India's Leading Fintech Platform</text>
+
+  <!-- Divider -->
+  <rect x="108" y="368" width="600" height="1" fill="rgba(99,102,241,0.2)"/>
+
+  <!-- Skills -->
+  <text x="108" y="406" font-family="Inter,-apple-system,sans-serif" font-size="20" fill="#64748b">AWS · Cloud Architecture · FinTech · Engineering Leadership</text>
+  <text x="108" y="438" font-family="Inter,-apple-system,sans-serif" font-size="20" fill="#64748b">React · Node.js · TypeScript · Microservices · DevOps</text>
+
+  <!-- Stats -->
+  <text x="108" y="498" font-family="Inter,-apple-system,sans-serif" font-size="28" font-weight="800" fill="#e2e8f0">12+</text>
+  <text x="108" y="522" font-family="Inter,-apple-system,sans-serif" font-size="13" fill="#64748b" letter-spacing="0.05em">YEARS EXP</text>
+
+  <text x="218" y="498" font-family="Inter,-apple-system,sans-serif" font-size="28" font-weight="800" fill="#e2e8f0">4+</text>
+  <text x="218" y="522" font-family="Inter,-apple-system,sans-serif" font-size="13" fill="#64748b" letter-spacing="0.05em">COMPANIES</text>
+
+  <text x="318" y="498" font-family="Inter,-apple-system,sans-serif" font-size="28" font-weight="800" fill="#e2e8f0">AWS</text>
+  <text x="318" y="522" font-family="Inter,-apple-system,sans-serif" font-size="13" fill="#64748b" letter-spacing="0.05em">CERTIFIED</text>
+
+  <!-- URL -->
+  <text x="108" y="580" font-family="'JetBrains Mono',monospace,sans-serif" font-size="18" fill="rgba(99,102,241,0.7)" letter-spacing="0.04em">elninad.github.io</text>
+
+  <!-- Decorative orb -->
+  <circle cx="1060" cy="315" r="190" fill="none" stroke="rgba(99,102,241,0.07)" stroke-width="1"/>
+  <circle cx="1060" cy="315" r="140" fill="none" stroke="rgba(139,92,246,0.05)" stroke-width="1"/>
+  <circle cx="1060" cy="315" r="90" fill="rgba(99,102,241,0.04)" stroke="rgba(99,102,241,0.08)" stroke-width="1"/>
+  <text x="1060" y="290" text-anchor="middle" font-family="'JetBrains Mono',monospace,sans-serif" font-size="40" fill="rgba(99,102,241,0.25)">&lt;</text>
+  <text x="1060" y="335" text-anchor="middle" font-family="'JetBrains Mono',monospace,sans-serif" font-size="44" font-weight="700" fill="rgba(139,92,246,0.3)">NM</text>
+  <text x="1060" y="380" text-anchor="middle" font-family="'JetBrains Mono',monospace,sans-serif" font-size="40" fill="rgba(99,102,241,0.25)">/&gt;</text>
+
+  <!-- Orbit dot -->
+  <circle cx="1060" cy="125" r="6" fill="#f59e0b" opacity="0.6"/>
+</svg>

--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,34 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://elninad.github.io/sitemap.xml
+User-agent: Googlebot
+Allow: /
+
+User-agent: Bingbot
+Allow: /
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Applebot
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+Sitemap: https://ninadmalvankar.com/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://elninad.github.io/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <loc>https://ninadmalvankar.com/</loc>
+    <lastmod>2026-04-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## Summary

Full SEO audit and implementation covering traditional search, social sharing, and Generative Engine Optimization (GEO) — making Ninad show up when anyone googles him or asks an AI assistant about him.

### Critical Fixes
- **Custom domain canonical**: All URLs (canonical, OG, Twitter, JSON-LD, sitemap) were pointing to `elninad.github.io` — now correctly point to `ninadmalvankar.com` (matching the CNAME). This was silently splitting SEO authority between two URLs.
- **Missing OG/Twitter images**: Added `og:image` and `twitter:image` pointing to the new `og-image.svg` (1200×630). Upgraded Twitter card from `summary` to `summary_large_image`.

### SEO Improvements (`index.html`)
| What | Before | After |
|---|---|---|
| Page title | `Ninad Malvankar — Senior Principal Engineer` | + `at Upstox` (adds company keyword) |
| Meta description | Brief, ~100 chars | Expanded with location, credentials, keywords |
| `robots` meta | `index, follow` | + `max-snippet:-1, max-image-preview:large` |
| Meta keywords | 11 terms | 23 terms (AWS CloudFront, AWS WAF, elninad, etc.) |
| `rel=me` links | None | LinkedIn, GitHub, Medium, X (identity verification) |
| `rel=author` | None | Added → LinkedIn |
| Geo meta | None | `geo.region: IN-MH`, `geo.placename: Mumbai`, lat/long |
| `og:image` | None | `https://ninadmalvankar.com/og-image.svg` |
| Twitter card type | `summary` | `summary_large_image` |
| `color-scheme` | None | `dark` |
| Sitemap `<link>` | None | Added `rel=sitemap` in `<head>` |
| Fonts perf | Only `preconnect fonts.googleapis.com` | + `preconnect fonts.gstatic.com crossorigin` |

### JSON-LD / Structured Data (GEO)
- **Person schema**: Added `image` (ImageObject), `PostalAddress` (Mumbai, Maharashtra, IN), `nationality`, `potentialAction` (CommunicateAction → LinkedIn), `knowsLanguage`, `publishingPrinciples`, expanded `knowsAbout` from 14 → 27 items, added WES credential, added `mainEntityOfPage`
- **New: `ProfilePage` schema** — the correct schema type for portfolio pages; explicitly links page → Person entity. LLMs and search engines use this to understand "this page IS about this person"
- **WebSite schema**: Added `creator`, `isAccessibleForFree`
- **Articles**: Expanded from 1 → 4 Medium articles, each with `articleSection` and `keywords`
- **FAQPage**: Expanded from 3 → 8 Q&As covering identity, specialisation, career history, education, AWS services, writing, and contact — the primary vector for AI answers about Ninad

### GEO (Generative Engine Optimization) — New Files
- **`llms.txt`** — emerging standard (like `robots.txt` for LLMs); structured plain-text bio, career timeline, writing index, and social links that AI crawlers read directly
- **`og-image.svg`** — branded 1200×630 social sharing image matching site's colour palette

### Support Files
- **`robots.txt`**: Added explicit `Allow: /` for `GPTBot`, `ChatGPT-User`, `CCBot`, `anthropic-ai`, `ClaudeBot`, `PerplexityBot`, `Applebot`, `Applebot-Extended` — ensures AI crawlers are not accidentally blocked
- **`sitemap.xml`**: Updated `lastmod` to `2026-04-21`, corrected domain to `ninadmalvankar.com`

## Audit Checklist

- [x] JSON-LD validates (8 schema nodes, no syntax errors)
- [x] No `elninad.github.io` URLs remaining in SEO-relevant attributes
- [x] Canonical matches custom domain `ninadmalvankar.com`
- [x] All 4 Medium articles indexed in structured data
- [x] 8 FAQ entries covering all likely LLM query patterns
- [x] `rel=me` links for identity graph
- [x] AI bots explicitly allowed in robots.txt
- [x] `llms.txt` created with full career context

## Note on OG Image

`og-image.svg` works for Discord, Slack, Google rich results, and Telegram previews. For Facebook and LinkedIn, convert `og-image.svg` to a PNG and update the `og:image` / `twitter:image` meta tags to point to the `.png` file. The SVG is a production-ready template for that conversion.

https://claude.ai/code/session_01Mx1Vb6MDRTsfAMgEceJmak