### PR TITLE
feat: comprehensive SEO & GEO audit — fix domain, schemas, AI crawler visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,32 +3,63 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Ninad Malvankar — Senior Principal Engineer</title>
-  <meta name="description" content="Ninad Malvankar — Senior Principal Engineer at Upstox. Specialising in cloud infrastructure, fintech platforms, and engineering leadership." />
+  <title>Ninad Malvankar | Senior Principal Engineer at Upstox</title>
+  <meta name="description" content="Ninad Malvankar is a Senior Principal Engineer at Upstox with 12+ years building cloud infrastructure and fintech platforms. AWS Certified. Expert in React, Node.js, system design, and engineering leadership. Mumbai, India." />
   <meta name="author" content="Ninad Malvankar" />
-  <meta name="robots" content="index, follow" />
-  <meta name="keywords" content="Ninad Malvankar, Senior Principal Engineer, Upstox, cloud infrastructure, fintech, engineering leadership, AWS, React, Node.js, microservices, system design" />
-  <link rel="canonical" href="https://elninad.github.io/" />
+  <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1" />
+  <meta name="keywords" content="Ninad Malvankar, Senior Principal Engineer, Upstox, cloud infrastructure, fintech engineering, engineering leadership, AWS, AWS Certified, React, Angular, Node.js, TypeScript, microservices, system design, platform engineering, DevOps, CI/CD, Cloudflare, CloudFront, AWS WAF, Nexus, Mumbai, India, elninad, principal engineer portfolio, software architect" />
+  <link rel="canonical" href="https://ninadmalvankar.com/" />
+
+  <!-- Geographic targeting -->
+  <meta name="geo.region" content="IN-MH" />
+  <meta name="geo.placename" content="Mumbai, Maharashtra, India" />
+
+  <!-- Dublin Core (citation signals) -->
+  <meta name="DC.title" content="Ninad Malvankar — Senior Principal Engineer" />
+  <meta name="DC.creator" content="Ninad Malvankar" />
+  <meta name="DC.subject" content="Cloud Infrastructure, FinTech, Engineering Leadership, Software Architecture" />
+  <meta name="DC.language" content="en" />
+
+  <!-- Application name -->
+  <meta name="application-name" content="Ninad Malvankar Portfolio" />
+
+  <!-- Entity linking — rel="me" for social graph / identity -->
+  <link rel="me" href="https://www.linkedin.com/in/ninadmalvankar/" />
+  <link rel="me" href="https://github.com/elninad" />
+  <link rel="me" href="https://medium.com/@ninad.malvankar23" />
+  <link rel="me" href="https://x.com/el_ninad" />
 
   <!-- Open Graph / Facebook -->
-  <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://elninad.github.io/" />
-  <meta property="og:title" content="Ninad Malvankar — Senior Principal Engineer" />
-  <meta property="og:description" content="Ninad Malvankar is a Senior Principal Engineer at Upstox with 12+ years of experience in cloud infrastructure, fintech platforms, and engineering leadership." />
+  <meta property="og:type" content="profile" />
+  <meta property="og:url" content="https://ninadmalvankar.com/" />
+  <meta property="og:title" content="Ninad Malvankar | Senior Principal Engineer at Upstox" />
+  <meta property="og:description" content="Ninad Malvankar is a Senior Principal Engineer at Upstox with 12+ years building cloud infrastructure and fintech platforms. AWS Certified. Expert in React, Node.js, system design, and engineering leadership." />
+  <meta property="og:image" content="https://ninadmalvankar.com/og-image.svg" />
+  <meta property="og:image:width" content="1200" />
+  <meta property="og:image:height" content="630" />
+  <meta property="og:image:alt" content="Ninad Malvankar — Senior Principal Engineer at Upstox. Cloud, FinTech, Engineering Leadership." />
   <meta property="og:site_name" content="Ninad Malvankar" />
   <meta property="og:locale" content="en_US" />
+  <meta property="profile:first_name" content="Ninad" />
+  <meta property="profile:last_name" content="Malvankar" />
+  <meta property="profile:username" content="elninad" />
 
   <!-- Twitter Card -->
-  <meta name="twitter:card" content="summary" />
-  <meta name="twitter:url" content="https://elninad.github.io/" />
-  <meta name="twitter:title" content="Ninad Malvankar — Senior Principal Engineer" />
-  <meta name="twitter:description" content="Ninad Malvankar is a Senior Principal Engineer at Upstox with 12+ years of experience in cloud infrastructure, fintech platforms, and engineering leadership." />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:url" content="https://ninadmalvankar.com/" />
+  <meta name="twitter:title" content="Ninad Malvankar | Senior Principal Engineer at Upstox" />
+  <meta name="twitter:description" content="Ninad Malvankar is a Senior Principal Engineer at Upstox with 12+ years building cloud infrastructure and fintech platforms. AWS Certified. React, Node.js, System Design." />
+  <meta name="twitter:image" content="https://ninadmalvankar.com/og-image.svg" />
+  <meta name="twitter:image:alt" content="Ninad Malvankar — Senior Principal Engineer at Upstox" />
+  <meta name="twitter:site" content="@el_ninad" />
   <meta name="twitter:creator" content="@el_ninad" />
 
   <!-- Theme -->
   <meta name="theme-color" content="#6366f1" />
 
   <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
   <style>
@@ -590,7 +621,7 @@
     "@graph": [
       {
         "@type": "Person",
-        "@id": "https://elninad.github.io/#person",
+        "@id": "https://ninadmalvankar.com/#person",
         "name": "Ninad Malvankar",
         "givenName": "Ninad",
         "familyName": "Malvankar",
@@ -599,9 +630,35 @@
           "@type": "Organization",
           "name": "Upstox",
           "url": "https://upstox.com",
-          "industry": "FinTech"
+          "industry": "FinTech",
+          "sameAs": "https://en.wikipedia.org/wiki/Upstox"
         },
-        "url": "https://elninad.github.io/",
+        "url": "https://ninadmalvankar.com/",
+        "image": "https://ninadmalvankar.com/og-image.svg",
+        "homeLocation": {
+          "@type": "Place",
+          "name": "Mumbai, Maharashtra, India",
+          "address": {
+            "@type": "PostalAddress",
+            "addressLocality": "Mumbai",
+            "addressRegion": "Maharashtra",
+            "addressCountry": "IN"
+          }
+        },
+        "nationality": {
+          "@type": "Country",
+          "name": "India"
+        },
+        "knowsLanguage": ["en", "mr", "hi"],
+        "hasOccupation": {
+          "@type": "Occupation",
+          "name": "Senior Principal Engineer",
+          "occupationLocation": {
+            "@type": "City",
+            "name": "Mumbai"
+          },
+          "skills": "Cloud Infrastructure, AWS CloudFront, AWS WAF, System Design, Engineering Leadership, FinTech Platform Engineering, React, Angular, Node.js, TypeScript, Microservices, DevOps, CI/CD, Cloudflare, Nexus Repository Manager"
+        },
         "sameAs": [
           "https://www.linkedin.com/in/ninadmalvankar/",
           "https://github.com/elninad",
@@ -623,19 +680,32 @@
         ],
         "knowsAbout": [
           "Cloud Infrastructure",
-          "AWS",
+          "Amazon Web Services",
+          "AWS CloudFront",
+          "AWS WAF",
+          "AWS S3",
           "FinTech",
           "Engineering Leadership",
           "System Design",
+          "Software Architecture",
+          "Platform Engineering",
           "Microservices",
           "DevOps",
+          "CI/CD Pipelines",
           "React",
+          "Angular",
           "Node.js",
           "TypeScript",
+          "JavaScript",
+          ".NET",
+          "C#",
           "Docker",
-          "CI/CD",
           "Cloudflare",
-          "Software Architecture"
+          "Nexus Repository Manager",
+          "Technical Mentorship",
+          "Principal Engineer Leadership",
+          "Distributed Systems",
+          "RESTful APIs"
         ],
         "hasCredential": [
           {
@@ -645,7 +715,18 @@
             "dateCreated": "2023",
             "recognizedBy": {
               "@type": "Organization",
-              "name": "Amazon Web Services"
+              "name": "Amazon Web Services",
+              "sameAs": "https://aws.amazon.com"
+            }
+          },
+          {
+            "@type": "EducationalOccupationalCredential",
+            "name": "Verified International Academic Qualifications",
+            "credentialCategory": "certification",
+            "dateCreated": "2023",
+            "recognizedBy": {
+              "@type": "Organization",
+              "name": "World Education Services (WES)"
             }
           },
           {
@@ -655,7 +736,8 @@
             "dateCreated": "2013",
             "recognizedBy": {
               "@type": "CollegeOrUniversity",
-              "name": "University of Texas at Arlington"
+              "name": "University of Texas at Arlington",
+              "sameAs": "https://www.uta.edu/"
             }
           },
           {
@@ -665,20 +747,57 @@
             "dateCreated": "2011",
             "recognizedBy": {
               "@type": "CollegeOrUniversity",
-              "name": "University of Mumbai"
+              "name": "University of Mumbai",
+              "sameAs": "https://mu.ac.in/"
             }
           }
         ],
-        "description": "Senior Principal Engineer at Upstox with 12+ years of experience building cloud infrastructure and fintech platforms. Expert in engineering leadership, system design, AWS, microservices, and DevOps. Previously worked at enSYNC Corporation and Swift Pace Solutions (Disney project). M.S. Computer Science from University of Texas at Arlington."
+        "description": "Ninad Malvankar is a Senior Principal Engineer at Upstox, India's leading discount brokerage platform. With 12+ years of experience building cloud infrastructure and fintech platforms at scale, he specialises in AWS, engineering leadership, system design, React, Node.js, TypeScript, and microservices. He holds an M.S. in Computer Science from the University of Texas at Arlington and a B.E. in Computer Engineering from the University of Mumbai. Previously worked on enterprise software at enSYNC Corporation (2013–2017) and a mission-critical project for Walt Disney World at Swift Pace Solutions (2017–2018)."
+      },
+      {
+        "@type": "ProfilePage",
+        "@id": "https://ninadmalvankar.com/#webpage",
+        "url": "https://ninadmalvankar.com/",
+        "name": "Ninad Malvankar — Senior Principal Engineer Portfolio",
+        "description": "Personal portfolio of Ninad Malvankar, Senior Principal Engineer at Upstox, showcasing career timeline, technical skills, certifications, and engineering writing.",
+        "dateModified": "2026-04-22",
+        "inLanguage": "en-US",
+        "isPartOf": {
+          "@id": "https://ninadmalvankar.com/#website"
+        },
+        "about": {
+          "@id": "https://ninadmalvankar.com/#person"
+        },
+        "mainEntity": {
+          "@id": "https://ninadmalvankar.com/#person"
+        },
+        "speakable": {
+          "@type": "SpeakableSpecification",
+          "cssSelector": [".hero-sub", ".about-text > p", ".quote"]
+        },
+        "breadcrumb": {
+          "@type": "BreadcrumbList",
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "Ninad Malvankar — Portfolio",
+              "item": "https://ninadmalvankar.com/"
+            }
+          ]
+        }
       },
       {
         "@type": "WebSite",
-        "@id": "https://elninad.github.io/#website",
-        "url": "https://elninad.github.io/",
-        "name": "Ninad Malvankar — Portfolio",
-        "description": "Personal portfolio of Ninad Malvankar, Senior Principal Engineer at Upstox, showcasing career timeline, technical skills, certifications, and engineering writing.",
+        "@id": "https://ninadmalvankar.com/#website",
+        "url": "https://ninadmalvankar.com/",
+        "name": "Ninad Malvankar — Senior Principal Engineer",
+        "description": "Personal portfolio of Ninad Malvankar, Senior Principal Engineer at Upstox. Cloud infrastructure, fintech, engineering leadership, and technical writing.",
         "author": {
-          "@id": "https://elninad.github.io/#person"
+          "@id": "https://ninadmalvankar.com/#person"
+        },
+        "publisher": {
+          "@id": "https://ninadmalvankar.com/#person"
         },
         "inLanguage": "en-US"
       },
@@ -687,27 +806,79 @@
         "@id": "https://medium.com/@ninad.malvankar23/the-role-of-a-principal-engineer-leadership-without-authority-c4f7b6dc1ccf#article",
         "headline": "The Role of a Principal Engineer — Leadership Without Authority",
         "url": "https://medium.com/@ninad.malvankar23/the-role-of-a-principal-engineer-leadership-without-authority-c4f7b6dc1ccf",
-        "description": "An exploration of how Principal Engineers lead through influence, expertise, and trust rather than formal authority.",
+        "description": "An exploration of how Principal Engineers lead through influence, expertise, and trust rather than formal authority. How to drive clarity, embrace ambiguity, and help teams move faster and smarter.",
         "author": {
-          "@id": "https://elninad.github.io/#person"
+          "@id": "https://ninadmalvankar.com/#person"
         },
         "publisher": {
           "@type": "Organization",
           "name": "Medium",
           "url": "https://medium.com"
         },
-        "inLanguage": "en-US"
+        "inLanguage": "en-US",
+        "keywords": ["principal engineer", "engineering leadership", "technical leadership", "influence without authority", "software engineering"]
+      },
+      {
+        "@type": "Article",
+        "@id": "https://medium.com/@ninad.malvankar23/what-happens-when-you-outgrow-mentorship-lessons-from-a-principal-engineer-0f7bc0672aa7#article",
+        "headline": "What Happens When You Outgrow Mentorship? Lessons from a Principal Engineer",
+        "url": "https://medium.com/@ninad.malvankar23/what-happens-when-you-outgrow-mentorship-lessons-from-a-principal-engineer-0f7bc0672aa7",
+        "description": "Outgrowing formal mentorship can feel isolating. Treating yourself like a system — running personal retrospectives each quarter and building your own feedback loop — is how growth continues at the principal level.",
+        "author": {
+          "@id": "https://ninadmalvankar.com/#person"
+        },
+        "publisher": {
+          "@type": "Organization",
+          "name": "Medium",
+          "url": "https://medium.com"
+        },
+        "inLanguage": "en-US",
+        "keywords": ["mentorship", "principal engineer", "career growth", "engineering leadership", "personal development"]
+      },
+      {
+        "@type": "Article",
+        "@id": "https://medium.com/@ninad.malvankar23/spring-security-meets-java-21-a-closer-look-at-firewall-controls-db4a9fc1d897#article",
+        "headline": "Spring Security Meets Java 21: A Closer Look at Firewall Controls",
+        "url": "https://medium.com/@ninad.malvankar23/spring-security-meets-java-21-a-closer-look-at-firewall-controls-db4a9fc1d897",
+        "description": "Many backend engineers upgrade to the latest Java and Spring versions for performance gains but overlook deeper security implications. A closer look at how Spring Security's firewall controls behave in a Java 21 environment.",
+        "author": {
+          "@id": "https://ninadmalvankar.com/#person"
+        },
+        "publisher": {
+          "@type": "Organization",
+          "name": "Medium",
+          "url": "https://medium.com"
+        },
+        "inLanguage": "en-US",
+        "keywords": ["Spring Security", "Java 21", "firewall", "backend security", "Spring Boot", "application security"]
+      },
+      {
+        "@type": "Article",
+        "@id": "https://medium.com/@ninad.malvankar23/how-a-bad-webpack-config-can-silently-destroy-frontend-performance-0622df39323f#article",
+        "headline": "How a Bad Webpack Config Can Silently Destroy Frontend Performance",
+        "url": "https://medium.com/@ninad.malvankar23/how-a-bad-webpack-config-can-silently-destroy-frontend-performance-0622df39323f",
+        "description": "Misconfigured bundlers don't always throw errors — sometimes they just make your app slower in ways that are hard to detect. A deep dive into the subtle ways webpack config mistakes can silently kill frontend performance.",
+        "author": {
+          "@id": "https://ninadmalvankar.com/#person"
+        },
+        "publisher": {
+          "@type": "Organization",
+          "name": "Medium",
+          "url": "https://medium.com"
+        },
+        "inLanguage": "en-US",
+        "keywords": ["webpack", "frontend performance", "bundler optimisation", "JavaScript", "React", "web performance"]
       },
       {
         "@type": "FAQPage",
-        "@id": "https://elninad.github.io/#faq",
+        "@id": "https://ninadmalvankar.com/#faq",
         "mainEntity": [
           {
             "@type": "Question",
             "name": "Who is Ninad Malvankar?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "Ninad Malvankar is a Senior Principal Engineer at Upstox, a leading Indian fintech platform. With 12+ years of experience, he specialises in cloud infrastructure (AWS), engineering leadership, system design, and microservices. He holds an M.S. in Computer Science from the University of Texas at Arlington and is AWS Certified."
+              "text": "Ninad Malvankar is a Senior Principal Engineer at Upstox, India's leading discount brokerage platform. With 12+ years of experience building cloud infrastructure and fintech platforms at scale, he specialises in AWS, engineering leadership, system design, React, Node.js, TypeScript, and microservices. He is based in Mumbai, India."
             }
           },
           {
@@ -715,7 +886,7 @@
             "name": "What does Ninad Malvankar specialise in?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "Ninad specialises in cloud architecture (AWS), fintech platform engineering, engineering leadership, system design, DevOps, microservices, and full-stack development using React, Node.js, TypeScript, and .NET/C#."
+              "text": "Ninad Malvankar specialises in cloud architecture (AWS CloudFront, WAF, S3), fintech platform engineering, engineering leadership, system design, DevOps, CI/CD pipelines, microservices, and full-stack development using React, Angular, Node.js, TypeScript, and .NET/C#. He also has expertise in Cloudflare CDN configuration and Nexus Repository management."
             }
           },
           {
@@ -723,7 +894,47 @@
             "name": "Where has Ninad Malvankar worked?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "Ninad has worked at Upstox (2018–present, currently as Senior Principal Engineer), Swift Pace Solutions Inc on a Disney project (2017–2018), enSYNC Corporation (2013–2017), and the University of Texas at Arlington (2012–2013). He has been at Upstox since 2018, progressing from Technology Lead to Principal Engineer to Senior Principal Engineer."
+              "text": "Ninad Malvankar has worked at Upstox (2018–present, currently as Senior Principal Engineer), Swift Pace Solutions Inc on a Walt Disney World project (2017–2018), enSYNC Corporation as Software Engineer (2013–2017), and the University of Texas at Arlington as Web Developer (2012–2013). At Upstox he progressed from Technology Lead (2018) to Principal Engineer (2021) to Senior Principal Engineer (2022–present)."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What is Ninad Malvankar's educational background?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Ninad Malvankar holds an M.S. in Computer Science from the University of Texas at Arlington (2011–2013) and a B.E. in Computer Engineering from the University of Mumbai (2007–2011). His academic qualifications have been internationally verified by World Education Services (WES) in 2023."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What certifications does Ninad Malvankar hold?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Ninad Malvankar is an AWS Certified Cloud Practitioner (2023). He also holds a Verified International Academic Qualifications credential from World Education Services (WES, 2023), an M.S. in Computer Science from the University of Texas at Arlington (2013), and a B.E. in Computer Engineering from the University of Mumbai (2011)."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What has Ninad Malvankar built at Upstox?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "At Upstox, Ninad Malvankar established a private npm registry via Nexus Repository Manager, created a unified deployment pipeline for React, Angular, and Node.js applications, configured AWS WAF ACLs to protect against web exploits, implemented AWS CloudFront caching for performance optimisation, and debugged complex API latency issues through Cloudflare edge routing. As Senior Principal Engineer since 2022, he leads cross-functional engineering teams, drives platform reliability, and shapes technical strategy across India's leading discount brokerage."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Where can I read Ninad Malvankar's engineering articles?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Ninad Malvankar writes about engineering leadership, system design, and platform engineering on Medium at https://medium.com/@ninad.malvankar23. His published articles include 'The Role of a Principal Engineer — Leadership Without Authority', 'What Happens When You Outgrow Mentorship?', 'Spring Security Meets Java 21: A Closer Look at Firewall Controls', and 'How a Bad Webpack Config Can Silently Destroy Frontend Performance'."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "How can I contact or connect with Ninad Malvankar?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "You can connect with Ninad Malvankar on LinkedIn at https://www.linkedin.com/in/ninadmalvankar/, follow him on GitHub at https://github.com/elninad, read his writing on Medium at https://medium.com/@ninad.malvankar23, or find him on X (Twitter) at @el_ninad and YouTube at @el_nino."
             }
           }
         ]

--- a/og-image.svg
+++ b/og-image.svg
@@ -1,0 +1,109 @@
+<svg width="1200" height="630" viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="bg1" cx="70%" cy="35%" r="65%">
+      <stop offset="0%" stop-color="#6366f1" stop-opacity="0.35"/>
+      <stop offset="100%" stop-color="#060b18" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="bg2" cx="15%" cy="80%" r="55%">
+      <stop offset="0%" stop-color="#8b5cf6" stop-opacity="0.25"/>
+      <stop offset="100%" stop-color="#060b18" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="bg3" cx="85%" cy="90%" r="45%">
+      <stop offset="0%" stop-color="#22d3ee" stop-opacity="0.15"/>
+      <stop offset="100%" stop-color="#060b18" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="nameGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#e2e8f0"/>
+      <stop offset="45%" stop-color="#818cf8"/>
+      <stop offset="100%" stop-color="#a78bfa"/>
+    </linearGradient>
+    <linearGradient id="accentBar" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#6366f1"/>
+      <stop offset="100%" stop-color="#8b5cf6"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="#060b18"/>
+  <rect width="1200" height="630" fill="url(#bg1)"/>
+  <rect width="1200" height="630" fill="url(#bg2)"/>
+  <rect width="1200" height="630" fill="url(#bg3)"/>
+
+  <!-- Subtle grid -->
+  <line x1="0" y1="105" x2="1200" y2="105" stroke="#6366f1" stroke-opacity="0.06" stroke-width="1"/>
+  <line x1="0" y1="210" x2="1200" y2="210" stroke="#6366f1" stroke-opacity="0.06" stroke-width="1"/>
+  <line x1="0" y1="315" x2="1200" y2="315" stroke="#6366f1" stroke-opacity="0.06" stroke-width="1"/>
+  <line x1="0" y1="420" x2="1200" y2="420" stroke="#6366f1" stroke-opacity="0.06" stroke-width="1"/>
+  <line x1="0" y1="525" x2="1200" y2="525" stroke="#6366f1" stroke-opacity="0.06" stroke-width="1"/>
+  <line x1="200" y1="0" x2="200" y2="630" stroke="#6366f1" stroke-opacity="0.06" stroke-width="1"/>
+  <line x1="400" y1="0" x2="400" y2="630" stroke="#6366f1" stroke-opacity="0.06" stroke-width="1"/>
+  <line x1="600" y1="0" x2="600" y2="630" stroke="#6366f1" stroke-opacity="0.06" stroke-width="1"/>
+  <line x1="800" y1="0" x2="800" y2="630" stroke="#6366f1" stroke-opacity="0.06" stroke-width="1"/>
+  <line x1="1000" y1="0" x2="1000" y2="630" stroke="#6366f1" stroke-opacity="0.06" stroke-width="1"/>
+
+  <!-- Left accent bar -->
+  <rect x="72" y="130" width="4" height="300" rx="2" fill="url(#accentBar)"/>
+
+  <!-- Badge pill -->
+  <rect x="92" y="118" width="270" height="36" rx="18" fill="#6366f1" fill-opacity="0.15" stroke="#6366f1" stroke-opacity="0.3" stroke-width="1"/>
+  <circle cx="112" cy="136" r="5" fill="#6366f1"/>
+  <text x="126" y="141" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="600" fill="#6366f1" letter-spacing="1.5">SENIOR PRINCIPAL ENGINEER</text>
+
+  <!-- Name -->
+  <text x="92" y="235" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="78" font-weight="900" fill="url(#nameGrad)" letter-spacing="-2">Ninad Malvankar</text>
+
+  <!-- Company -->
+  <text x="94" y="295" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="30" font-weight="700" fill="#f59e0b" letter-spacing="0.5">Upstox · Cloud Infrastructure · FinTech</text>
+
+  <!-- Divider -->
+  <rect x="92" y="326" width="100" height="3" rx="1.5" fill="url(#accentBar)"/>
+
+  <!-- Description -->
+  <text x="92" y="370" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="20" fill="#94a3b8" letter-spacing="0.2">12+ years building platforms at scale · AWS Certified · Mumbai, India</text>
+
+  <!-- Tech pills -->
+  <rect x="92" y="410" width="72" height="30" rx="8" fill="#6366f1" fill-opacity="0.15" stroke="#6366f1" stroke-opacity="0.25" stroke-width="1"/>
+  <text x="128" y="430" font-family="'JetBrains Mono', 'Courier New', monospace" font-size="13" font-weight="600" fill="#6366f1" text-anchor="middle">AWS</text>
+
+  <rect x="176" y="410" width="74" height="30" rx="8" fill="#6366f1" fill-opacity="0.15" stroke="#6366f1" stroke-opacity="0.25" stroke-width="1"/>
+  <text x="213" y="430" font-family="'JetBrains Mono', 'Courier New', monospace" font-size="13" font-weight="600" fill="#6366f1" text-anchor="middle">React</text>
+
+  <rect x="262" y="410" width="90" height="30" rx="8" fill="#6366f1" fill-opacity="0.15" stroke="#6366f1" stroke-opacity="0.25" stroke-width="1"/>
+  <text x="307" y="430" font-family="'JetBrains Mono', 'Courier New', monospace" font-size="13" font-weight="600" fill="#6366f1" text-anchor="middle">Node.js</text>
+
+  <rect x="364" y="410" width="118" height="30" rx="8" fill="#6366f1" fill-opacity="0.15" stroke="#6366f1" stroke-opacity="0.25" stroke-width="1"/>
+  <text x="423" y="430" font-family="'JetBrains Mono', 'Courier New', monospace" font-size="13" font-weight="600" fill="#6366f1" text-anchor="middle">TypeScript</text>
+
+  <rect x="494" y="410" width="148" height="30" rx="8" fill="#6366f1" fill-opacity="0.15" stroke="#6366f1" stroke-opacity="0.25" stroke-width="1"/>
+  <text x="568" y="430" font-family="'JetBrains Mono', 'Courier New', monospace" font-size="13" font-weight="600" fill="#6366f1" text-anchor="middle">System Design</text>
+
+  <rect x="654" y="410" width="138" height="30" rx="8" fill="#22d3ee" fill-opacity="0.12" stroke="#22d3ee" stroke-opacity="0.25" stroke-width="1"/>
+  <text x="723" y="430" font-family="'JetBrains Mono', 'Courier New', monospace" font-size="13" font-weight="600" fill="#22d3ee" text-anchor="middle">Microservices</text>
+
+  <!-- Stats row -->
+  <line x1="92" y1="490" x2="900" y2="490" stroke="#1e2d4d" stroke-width="1"/>
+
+  <text x="92" y="530" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="32" font-weight="800" fill="#e2e8f0">12+</text>
+  <text x="92" y="558" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" fill="#64748b" letter-spacing="1">YRS EXP</text>
+
+  <line x1="190" y1="505" x2="190" y2="565" stroke="#1e2d4d" stroke-width="1"/>
+
+  <text x="210" y="530" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="32" font-weight="800" fill="#e2e8f0">4+</text>
+  <text x="210" y="558" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" fill="#64748b" letter-spacing="1">COMPANIES</text>
+
+  <line x1="350" y1="505" x2="350" y2="565" stroke="#1e2d4d" stroke-width="1"/>
+
+  <text x="370" y="530" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="32" font-weight="800" fill="#f59e0b">AWS</text>
+  <text x="370" y="558" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" fill="#64748b" letter-spacing="1">CERTIFIED</text>
+
+  <line x1="500" y1="505" x2="500" y2="565" stroke="#1e2d4d" stroke-width="1"/>
+
+  <text x="520" y="530" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="32" font-weight="800" fill="#22d3ee">FinTech</text>
+  <text x="520" y="558" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" fill="#64748b" letter-spacing="1">DOMAIN</text>
+
+  <!-- URL -->
+  <text x="92" y="600" font-family="'JetBrains Mono', 'Courier New', monospace" font-size="18" fill="#64748b">ninadmalvankar.com</text>
+
+  <!-- Logo mark -->
+  <text x="1090" y="590" font-family="'JetBrains Mono', 'Courier New', monospace" font-size="32" font-weight="600" fill="#6366f1" text-anchor="middle">&lt;NM /&gt;</text>
+</svg>

--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,20 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://elninad.github.io/sitemap.xml
+# AI crawlers — allow for GEO (Generative Engine Optimization)
+User-agent: GPTBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: Applebot
+Allow: /
+
+Sitemap: https://ninadmalvankar.com/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://elninad.github.io/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <loc>https://ninadmalvankar.com/</loc>
+    <lastmod>2026-04-22</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## Summary

This PR contains a full SEO + GEO (Generative Engine Optimization) audit and fix pass for ninadmalvankar.com. Changes span structured data, meta tags, social sharing, AI crawler access, and a new branded OG image.

---

## Critical Fix

- **Wrong canonical domain** — All canonical URLs, JSON-LD `@id` refs, and OG/Twitter tags were pointing to `elninad.github.io` instead of the custom domain `ninadmalvankar.com`. This is a fundamental SEO error (duplicate content signal, wrong entity identity). **Fixed throughout.**

---

## SEO Changes

### Meta Tags
- Improved `<title>`: Now includes company name — `Ninad Malvankar | Senior Principal Engineer at Upstox`
- Improved `<meta name="description">`: More specific, includes AWS Certified and location signals
- Expanded `<meta name="keywords">`: 25+ terms covering all tech skills, location, certifications
- Updated `robots` meta: added `max-snippet:-1, max-image-preview:large, max-video-preview:-1`

### Social Sharing
- Upgraded Twitter card from `summary` → **`summary_large_image`** (shows full image previews)
- Added `og:image`, `og:image:width/height/alt` — was completely missing before
- Added `twitter:image`, `twitter:image:alt`, `twitter:site`
- Added `og:type=profile` with `profile:first_name/last_name/username`

### Technical SEO
- Added `<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />` (fonts load faster)
- Added `<link rel="dns-prefetch" href="https://cdnjs.cloudflare.com" />` (icon font load faster)
- Updated `sitemap.xml`: correct domain, `lastmod` updated to `2026-04-22`
- Updated `robots.txt`: correct sitemap URL

---

## GEO (Generative Engine Optimization) Changes

### JSON-LD Structured Data — Complete Overhaul

| Schema Type | Before | After |
|---|---|---|
| `Person` | Basic | Full: homeLocation, nationality, knowsLanguage, hasOccupation, image, 26 knowsAbout topics, all 4 credentials |
| `ProfilePage` | ❌ Missing | ✅ Added — primary LLM entity signal |
| `WebSite` | Basic | With publisher field |
| `Article` | 1 article | All **4 Medium articles** with keywords |
| `FAQPage` | 3 questions | **8 questions** covering who, what, where, education, certs, work, writing, contact |
| `Speakable` | ❌ Missing | ✅ Added on ProfilePage for voice/AI search |

### Entity Linking
- Added `<link rel="me">` tags to LinkedIn, GitHub, Medium, X — establishes identity graph for LLMs and Google Knowledge Graph

### Geographic Signals
- Added `geo.region: IN-MH`, `geo.placename: Mumbai, Maharashtra, India`

### Dublin Core Citation Signals
- Added `DC.title`, `DC.creator`, `DC.subject`, `DC.language` — helps academic/citation indexers

### AI Crawler Access (`robots.txt`)
- Explicitly allowed: `GPTBot` (OpenAI), `Claude-Web` (Anthropic), `PerplexityBot`, `Google-Extended` (Gemini), `Applebot`

### OG Image
- Created `og-image.svg` (1200×630) — a branded social sharing card with name, title, company, tech pills, and stats. Was completely absent before.

---

## Audit Checklist

- [x] Canonical URL correct (`ninadmalvankar.com`)
- [x] All JSON-LD `@id` refs use correct domain
- [x] `og:image` present and sized correctly (1200×630)
- [x] Twitter card upgraded to `summary_large_image`
- [x] `rel="me"` entity links in `<head>`
- [x] `ProfilePage` schema added (critical for LLM entity recognition)
- [x] `Speakable` schema added
- [x] All 4 Medium articles in structured data
- [x] 8 FAQ entries covering all major queries about Ninad
- [x] AI crawler bots explicitly allowed in robots.txt
- [x] Sitemap domain and lastmod updated
- [x] Geographic meta tags added
- [x] Dublin Core citation signals added
- [x] Font preconnect performance fix

## Recommended Next Steps (not in this PR)
- Add a PNG/JPG version of the OG image for Facebook compatibility (Facebook doesn't render SVG)
- Register site in Google Search Console and submit sitemap
- Submit profile to LinkedIn and other directories for backlink authority
- Consider adding `datePublished` to Medium articles once exact dates are confirmed

https://claude.ai/code/session_013kofugzZJvRruM1u2daFQX