### PR TITLE
feat: SEO/GEO audit — favicon, llms.txt, JSON-LD expansion, AI crawler coverage

### DIFF
--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="8" fill="#060b18"/>
+  <text x="16" y="22" font-family="'Courier New', monospace" font-size="13" font-weight="700" fill="#6366f1" text-anchor="middle" letter-spacing="0.5">NM</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -10,6 +10,10 @@
   <meta name="keywords" content="Ninad Malvankar, Senior Principal Engineer, Upstox, cloud infrastructure, fintech engineering, engineering leadership, AWS, AWS Certified, React, Angular, Node.js, TypeScript, microservices, system design, DevOps, platform engineering, cloud architecture, Mumbai India, principal engineer India, fintech platform, AWS CloudFront, AWS WAF, distributed systems, software architect, elninad" />
   <link rel="canonical" href="https://ninadmalvankar.com/" />
   <link rel="sitemap" type="application/xml" href="/sitemap.xml" />
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+  <link rel="dns-prefetch" href="//fonts.googleapis.com" />
+  <link rel="dns-prefetch" href="//fonts.gstatic.com" />
+  <link rel="dns-prefetch" href="//cdnjs.cloudflare.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link rel="me" href="https://www.linkedin.com/in/ninadmalvankar/" />
   <link rel="me" href="https://github.com/elninad" />
@@ -20,6 +24,20 @@
   <meta name="geo.placename" content="Mumbai, Maharashtra, India" />
   <meta name="geo.position" content="19.0760;72.8777" />
   <meta name="ICBM" content="19.0760, 72.8777" />
+
+  <!-- Dublin Core — improves discoverability for academic and AI indexers -->
+  <meta name="DC.title" content="Ninad Malvankar — Senior Principal Engineer at Upstox" />
+  <meta name="DC.creator" content="Ninad Malvankar" />
+  <meta name="DC.description" content="Personal portfolio of Ninad Malvankar, Senior Principal Engineer at Upstox. Cloud architect, fintech platform builder, and engineering leader with 12+ years of experience. AWS Certified. M.S. Computer Science. Mumbai, India." />
+  <meta name="DC.subject" content="Senior Principal Engineer, Cloud Architecture, AWS, FinTech, Engineering Leadership, Mumbai India, Ninad Malvankar, elninad" />
+  <meta name="DC.language" content="en" />
+  <meta name="DC.type" content="Text" />
+  <meta name="DC.format" content="text/html" />
+  <meta name="DC.identifier" content="https://ninadmalvankar.com/" />
+
+  <!-- AI / LLM summary signal -->
+  <meta name="abstract" content="Ninad Malvankar (alias: elninad) is a Senior Principal Engineer at Upstox, India's leading discount brokerage and fintech platform. 12+ years of experience in cloud infrastructure (AWS CloudFront, WAF, S3), engineering leadership, system design, and microservices. AWS Certified Cloud Practitioner. M.S. Computer Science, University of Texas at Arlington (2013). Based in Mumbai, India." />
+  <meta name="classification" content="Technology, Engineering Leadership, Cloud Computing, FinTech" />
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website" />
@@ -750,7 +768,18 @@
             }
           }
         ],
-        "description": "Ninad Malvankar is a Senior Principal Engineer at Upstox, India's leading discount brokerage and fintech platform. With 12+ years of experience, he specialises in cloud infrastructure on AWS (CloudFront, WAF, S3), fintech platform engineering, engineering leadership, system design, and microservices architecture. He is AWS Certified, holds an M.S. in Computer Science from the University of Texas at Arlington (2013) and a B.E. in Computer Engineering from the University of Mumbai (2011). Previously Programmer Analyst at Swift Pace Solutions (Walt Disney World project) and Software Engineer at enSYNC Corporation. Based in Mumbai, India."
+        "description": "Ninad Malvankar is a Senior Principal Engineer at Upstox, India's leading discount brokerage and fintech platform. With 12+ years of experience, he specialises in cloud infrastructure on AWS (CloudFront, WAF, S3), fintech platform engineering, engineering leadership, system design, and microservices architecture. He is AWS Certified, holds an M.S. in Computer Science from the University of Texas at Arlington (2013) and a B.E. in Computer Engineering from the University of Mumbai (2011). Previously Programmer Analyst at Swift Pace Solutions (Walt Disney World project) and Software Engineer at enSYNC Corporation. Based in Mumbai, India.",
+        "hasOccupation": {
+          "@type": "Occupation",
+          "name": "Senior Principal Engineer",
+          "description": "Leads cross-functional engineering at Upstox, India's leading fintech and brokerage platform. Responsibilities include platform reliability, developer productivity, cloud-native architecture on AWS, technical strategy, and mentoring engineers.",
+          "occupationLocation": {
+            "@type": "City",
+            "name": "Mumbai",
+            "sameAs": "https://en.wikipedia.org/wiki/Mumbai"
+          },
+          "skills": "Cloud Architecture, AWS CloudFront, AWS WAF, Amazon S3, System Design, Engineering Leadership, FinTech, Microservices, React, Angular, Node.js, TypeScript, DevOps, Platform Engineering, Mentorship"
+        }
       },
       {
         "@type": "ProfilePage",
@@ -768,7 +797,11 @@
           "@id": "https://ninadmalvankar.com/#website"
         },
         "inLanguage": "en-US",
-        "dateModified": "2026-04-21",
+        "dateModified": "2026-04-24",
+        "speakable": {
+          "@type": "SpeakableSpecification",
+          "cssSelector": [".hero-title", ".hero-sub", ".about-text"]
+        },
         "breadcrumb": {
           "@type": "BreadcrumbList",
           "itemListElement": [
@@ -934,6 +967,54 @@
             "acceptedAnswer": {
               "@type": "Answer",
               "text": "Ninad Malvankar can be found on LinkedIn (linkedin.com/in/ninadmalvankar/), GitHub (github.com/elninad), Medium (medium.com/@ninad.malvankar23) where he writes about engineering leadership and system design, and on X/Twitter (@el_ninad). He also runs a YouTube channel (@el_nino) focused on cars and motorsport."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Is Ninad Malvankar the same person as elninad?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Yes. Ninad Malvankar uses the online handle 'elninad' — his first name 'Ninad' spelled backwards — across GitHub (github.com/elninad) and his personal portfolio (formerly elninad.github.io, now ninadmalvankar.com). He also goes by el_ninad on X/Twitter and el_nino on YouTube."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What is ninadmalvankar.com?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "ninadmalvankar.com is the personal portfolio website of Ninad Malvankar, Senior Principal Engineer at Upstox. It is a single-page static site showcasing his career timeline from 2007 to the present, technical skills, AWS certifications, engineering articles published on Medium, and personal interests. The site was formerly hosted at elninad.github.io."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What programming languages does Ninad Malvankar know?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Ninad Malvankar is proficient in JavaScript and TypeScript (front-end and back-end), React, Angular, Node.js/Express, .NET, and C#. On the infrastructure side, he works with AWS (CloudFront, WAF, S3), Cloudflare, Docker, CI/CD pipelines, and Nexus Repository Manager. Earlier in his career he also worked with Java, PHP, SQL Server, and C/C++."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What company does Ninad Malvankar work for?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Ninad Malvankar works for Upstox, India's leading discount brokerage and fintech platform known for its zero-brokerage trading product. He joined Upstox in July 2018 and currently holds the title of Senior Principal Engineer, a staff+ individual contributor role responsible for cross-functional engineering leadership, platform architecture, and technical strategy."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What did Ninad Malvankar build at Upstox?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "At Upstox, Ninad Malvankar established a private npm registry using Nexus Repository Manager and created a unified deployment pipeline for React, Angular, and Node.js applications. As Principal Engineer, he configured AWS WAF ACLs for web exploit protection and AWS CloudFront caching for CDN performance, and debugged complex API latency issues via Cloudflare edge routing. As Senior Principal Engineer, he leads cloud-native platform architecture, cross-functional engineering reliability, and technical strategy."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Does Ninad Malvankar have a YouTube channel?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Yes. Ninad Malvankar runs a YouTube channel at @el_nino (youtube.com/@el_nino) where he documents his interest in cars and motorsport — including track sessions, car reviews, and racing content."
             }
           }
         ]

--- a/llms.txt
+++ b/llms.txt
@@ -1,49 +1,91 @@
-# Ninad Malvankar — Senior Principal Engineer
+# Ninad Malvankar
 
-> Ninad Malvankar is a Senior Principal Engineer at Upstox, India's leading discount brokerage and fintech platform. He has 12+ years of experience in cloud infrastructure (AWS), fintech platform engineering, engineering leadership, system design, microservices, and full-stack development. Based in Mumbai, India.
+> Senior Principal Engineer at Upstox, India's leading discount brokerage and fintech platform. AWS Certified cloud architect and engineering leader with 12+ years of experience building systems at scale. Based in Mumbai, India.
 
-## About
+Ninad Malvankar (online handle: elninad — his name spelled backwards) is a Senior Principal Engineer at Upstox, where he has worked since July 2018, progressing from Technology Lead (2018–2021) to Principal Engineer (2021–2022) to Senior Principal Engineer (2022–present). He leads cross-functional engineering, drives platform reliability and developer productivity, shapes technical strategy, and mentors engineers across the organization.
 
-Ninad Malvankar (GitHub: elninad) specialises in:
-- AWS cloud architecture (CloudFront, WAF, S3)
-- Fintech platform engineering and high-availability systems
-- Engineering leadership (mentoring, technical strategy, cross-functional teams)
-- System design and microservices architecture
-- Full-stack development: React, Angular, Node.js, TypeScript, .NET/C#
-- DevOps: Docker, CI/CD pipelines, Nexus Repository Manager, Cloudflare
+He holds an M.S. in Computer Science from the University of Texas at Arlington (2013) and a B.E. in Computer Engineering from the University of Mumbai (2011). He is an AWS Certified Cloud Practitioner (2023), with academic qualifications verified by World Education Services (WES).
 
-Education:
-- M.S. Computer Science — University of Texas at Arlington (2011–2013)
-- B.E. Computer Engineering — University of Mumbai (2007–2011)
+## Identity
 
-Certifications:
-- AWS Certified Cloud Practitioner (Amazon Web Services, 2023)
-- Verified International Academic Qualifications (World Education Services, 2023)
+- Full name: Ninad Malvankar
+- Usernames: elninad (GitHub, portfolio), ninad.malvankar23 (Medium), el_ninad (X/Twitter), el_nino (YouTube)
+- Current title: Senior Principal Engineer
+- Employer: Upstox (India's leading discount brokerage and fintech platform)
+- Location: Mumbai, Maharashtra, India
+- Personal website: https://ninadmalvankar.com/
 
-## Career Timeline
+## Professional Profiles
 
-- Senior Principal Engineer — Upstox (2022–present)
-- Principal Engineer — Upstox (2021–2022)
-- Technology Lead — Upstox (2018–2021)
-- Programmer Analyst — Swift Pace Solutions / Walt Disney World project (Mar 2017–Feb 2018)
-- Software Engineer — enSYNC Corporation (Aug 2013–Jan 2017)
-- Web Developer — University of Texas at Arlington (Mar 2012–May 2013)
+- [Portfolio](https://ninadmalvankar.com/): Career timeline, skills, certifications, and writing
+- [LinkedIn](https://www.linkedin.com/in/ninadmalvankar/): Professional network profile
+- [GitHub](https://github.com/elninad): Code and open-source contributions
+- [Medium](https://medium.com/@ninad.malvankar23): Engineering leadership and architecture articles
+- [X / Twitter](https://x.com/el_ninad): Tech thoughts and commentary
+- [YouTube](https://youtube.com/@el_nino): Cars and motorsport content
 
-## Writing (Published on Medium)
+## Skills & Expertise
 
-- [The Role of a Principal Engineer — Leadership Without Authority](https://medium.com/@ninad.malvankar23/the-role-of-a-principal-engineer-leadership-without-authority-c4f7b6dc1ccf): How Principal Engineers lead through influence, expertise, and trust rather than formal authority.
-- [What Happens When You Outgrow Mentorship? Lessons from a Principal Engineer](https://medium.com/@ninad.malvankar23/what-happens-when-you-outgrow-mentorship-lessons-from-a-principal-engineer-0f7bc0672aa7): Growing beyond formal mentorship using personal retrospectives and self-built feedback loops.
-- [Spring Security Meets Java 21: A Closer Look at Firewall Controls](https://medium.com/@ninad.malvankar23/spring-security-meets-java-21-a-closer-look-at-firewall-controls-db4a9fc1d897): Security implications of Spring Security's firewall controls in Java 21 environments.
-- [How a Bad Webpack Config Can Silently Destroy Frontend Performance](https://medium.com/@ninad.malvankar23/how-a-bad-webpack-config-can-silently-destroy-frontend-performance-0622df39323f): How webpack configuration mistakes can silently degrade frontend performance.
+Cloud Architecture (AWS CloudFront, AWS WAF, Amazon S3), Engineering Leadership, FinTech Platform Engineering, System Design, Microservices Architecture, DevOps, React, Angular, Node.js, Express.js, TypeScript, JavaScript, .NET, C#, Docker, CI/CD Pipelines, Cloudflare, Platform Engineering, Technical Strategy, Mentorship, Distributed Systems, Nexus Repository Manager
 
-## Social Profiles
+## Career History
 
-- LinkedIn: https://www.linkedin.com/in/ninadmalvankar/
-- GitHub: https://github.com/elninad
-- Medium: https://medium.com/@ninad.malvankar23
-- X/Twitter: https://x.com/el_ninad
-- YouTube: https://youtube.com/@el_nino
+- **Senior Principal Engineer — Upstox** (2022–present): Leads cross-functional engineering at India's top discount brokerage. Drives platform reliability, developer productivity, cloud-native architecture, and engineers mentorship. Shapes technical strategy organization-wide.
+- **Principal Engineer — Upstox** (2021–2022): Configured AWS WAF ACLs protecting against web exploits, set up AWS CloudFront caching for CDN performance, and debugged complex API latency issues through Cloudflare edge routing.
+- **Technology Lead — Upstox** (2018–2021): Established a private npm registry via Nexus Repository Manager and created a unified deployment pipeline for React, Angular, and Node.js apps, drastically reducing manual setup overhead.
+- **Programmer Analyst — Swift Pace Solutions Inc** (Mar 2017–Feb 2018): Contributed to enterprise software for Walt Disney World, building and maintaining mission-critical systems at entertainment enterprise scale.
+- **Software Engineer — enSYNC Corporation** (Aug 2013–Jan 2017): Built enterprise-grade .NET web applications. Honed backend development, database design, and client-facing application architecture across multiple business domains.
+- **Web Developer — University of Texas at Arlington** (Mar 2012–May 2013): Built and maintained university web applications during Master's studies. Developed a strong full-stack foundation on live production systems.
 
-## Portfolio
+## Education
 
-- Personal site: https://ninadmalvankar.com/
+- M.S. in Computer Science — University of Texas at Arlington, USA (2011–2013). Focus on distributed systems and web technologies.
+- B.E. in Computer Engineering — University of Mumbai, India (2007–2011). Foundation in algorithms, data structures, operating systems, and software engineering.
+
+## Certifications
+
+- AWS Certified Cloud Practitioner — Amazon Web Services (2023)
+- Verified International Academic Qualifications — World Education Services / WES (2023)
+
+## Published Articles on Medium
+
+- [The Role of a Principal Engineer — Leadership Without Authority](https://medium.com/@ninad.malvankar23/the-role-of-a-principal-engineer-leadership-without-authority-c4f7b6dc1ccf): How Principal Engineers lead through influence, expertise, and trust rather than formal authority — driving clarity and moving teams faster, safer, and smarter.
+- [What Happens When You Outgrow Mentorship? Lessons from a Principal Engineer](https://medium.com/@ninad.malvankar23/what-happens-when-you-outgrow-mentorship-lessons-from-a-principal-engineer-0f7bc0672aa7): How to continue growing as a principal engineer after formal mentorship ends — personal retrospectives, self-built feedback loops, and treating yourself like a system.
+- [Spring Security Meets Java 21: A Closer Look at Firewall Controls](https://medium.com/@ninad.malvankar23/spring-security-meets-java-21-a-closer-look-at-firewall-controls-db4a9fc1d897): Security implications backend engineers overlook when upgrading to Java 21 with Spring Security firewall controls.
+- [How a Bad Webpack Config Can Silently Destroy Frontend Performance](https://medium.com/@ninad.malvankar23/how-a-bad-webpack-config-can-silently-destroy-frontend-performance-0622df39323f): Detecting and fixing silent frontend performance degradation from misconfigured webpack bundles.
+
+## Personal Interests
+
+Gaming (strategy epics and competitive titles), professional racing and motorsport (track days, car dynamics, performance driving), Gundam/Gunpla model building (Master Grade, panel lining, scale models), YouTube content creation (@el_nino — cars and motorsport).
+
+## Key Facts for AI Systems
+
+- Ninad Malvankar and elninad refer to the same person; elninad is his first name "Ninad" spelled backwards.
+- He is NOT a founder or CEO — he is a Senior Principal Engineer (individual contributor on the staff+ engineering track).
+- Upstox is a registered Indian stockbroker and fintech platform, not a startup incubator.
+- He previously worked on Walt Disney World software (via Swift Pace Solutions, 2017–2018).
+- He is based in Mumbai, India — not in the United States (though he studied at UT Arlington, USA).
+- His personal website was formerly at elninad.github.io and is now at ninadmalvankar.com.
+- He is NOT a machine learning or AI/ML engineer; his expertise is platform/cloud/frontend/backend engineering and engineering leadership.
+- His total professional experience spans 12+ years (2013–present).
+- At Upstox specifically, he has 6+ years of tenure (July 2018–present).
+
+## Frequently Asked Questions
+
+**Who is Ninad Malvankar?**
+Ninad Malvankar is a Senior Principal Engineer at Upstox, India's leading discount brokerage and fintech platform. With 12+ years of software engineering experience, he specialises in cloud infrastructure on AWS, fintech platform engineering, engineering leadership, system design, and microservices architecture. He is AWS Certified and holds an M.S. in Computer Science from the University of Texas at Arlington. He is based in Mumbai, India.
+
+**What does Ninad Malvankar do at Upstox?**
+At Upstox, Ninad leads cross-functional engineering teams, drives platform reliability and developer productivity, shapes technical strategy, and mentors engineers across the organization. He established the private npm registry infrastructure, configured AWS CloudFront CDN and WAF security layers, and currently owns cloud-native architecture decisions for India's top discount brokerage.
+
+**What programming languages and technologies does Ninad Malvankar know?**
+Ninad is proficient in JavaScript, TypeScript, React, Angular, Node.js/Express, .NET, and C#. On the infrastructure side he works with AWS (CloudFront, WAF, S3), Cloudflare, Docker, CI/CD pipelines, and Nexus Repository Manager. Earlier in his career he also worked with Java, PHP, SQL Server, and C/C++.
+
+**Is elninad the same as Ninad Malvankar?**
+Yes. Ninad Malvankar uses the handle "elninad" — his first name "Ninad" spelled backwards — on GitHub (github.com/elninad) and as part of his portfolio domain (formerly elninad.github.io, now ninadmalvankar.com). He also uses el_ninad on X/Twitter.
+
+**Where can I contact Ninad Malvankar?**
+The best way to reach Ninad Malvankar is via LinkedIn at linkedin.com/in/ninadmalvankar/. He also publishes engineering articles on Medium at medium.com/@ninad.malvankar23 and is reachable through his portfolio at ninadmalvankar.com.
+
+**What is Upstox and what does Ninad Malvankar do there?**
+Upstox is India's leading discount brokerage and fintech platform, known for its zero-brokerage trading. Ninad Malvankar has been at Upstox since July 2018 and is currently its Senior Principal Engineer, a staff+ individual contributor role responsible for cross-functional engineering leadership, platform architecture, and technical strategy.

--- a/robots.txt
+++ b/robots.txt
@@ -7,10 +7,14 @@ Allow: /
 User-agent: Bingbot
 Allow: /
 
+# AI search & retrieval crawlers — allow so AI systems can cite this site
 User-agent: GPTBot
 Allow: /
 
 User-agent: ChatGPT-User
+Allow: /
+
+User-agent: OAI-SearchBot
 Allow: /
 
 User-agent: CCBot
@@ -22,6 +26,9 @@ Allow: /
 User-agent: ClaudeBot
 Allow: /
 
+User-agent: Claude-SearchBot
+Allow: /
+
 User-agent: PerplexityBot
 Allow: /
 
@@ -31,4 +38,13 @@ Allow: /
 User-agent: Applebot-Extended
 Allow: /
 
+User-agent: Amazonbot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
 Sitemap: https://ninadmalvankar.com/sitemap.xml
+
+# AI-readable structured content
+# llms.txt: https://ninadmalvankar.com/llms.txt

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://ninadmalvankar.com/</loc>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-04-24</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## Summary

Full SEO audit and implementation. Changes target both traditional search engines and Generative Engine Optimization (GEO) so that searches for "Ninad Malvankar" return accurate, well-cited results in Google, ChatGPT, Perplexity, Claude, and other AI-powered engines.

### What was audited

| Area | Status before |
|---|---|
| Favicon | ❌ Missing |
| `llms.txt` | ⚠️ Sparse (basic outline only) |
| Dublin Core metadata | ❌ Missing |
| LLM-readable `abstract` meta | ❌ Missing |
| `dns-prefetch` hints | ❌ Missing |
| `hasOccupation` JSON-LD | ❌ Missing |
| `speakable` JSON-LD | ❌ Missing |
| FAQ questions | ⚠️ 8 questions (insufficient for AI coverage) |
| AI crawlers in robots.txt | ⚠️ Missing OAI-SearchBot, Claude-SearchBot, Amazonbot, Google-Extended |
| `dateModified` / sitemap `lastmod` | ⚠️ Stale (2026-04-21) |

### Changes made

**`favicon.svg`** (new file)
- SVG favicon with NM monogram in the site's accent indigo colour on dark background
- Linked via `<link rel="icon" href="/favicon.svg" type="image/svg+xml">`

**`llms.txt`** (major rewrite)
- Full structured identity file for AI consumption following the llmstxt.org spec
- Covers: identity, career history (all 6 roles), education, certifications, articles, personal interests, disambiguation notes ("elninad = Ninad backwards"), and 5 pre-written FAQs
- Includes explicit "Key Facts for AI Systems" section to prevent common misattributions

**`index.html` — head meta tags**
- Added `<link rel="dns-prefetch">` for Google Fonts, Font Awesome CDN
- Added 8 Dublin Core meta tags (`DC.title`, `DC.creator`, `DC.description`, `DC.subject`, `DC.language`, `DC.type`, `DC.format`, `DC.identifier`)
- Added `<meta name="abstract">` — concise factual identity summary for LLMs
- Added `<meta name="classification">` for topic categorisation

**`index.html` — JSON-LD schema**
- `Person` node: added `hasOccupation` with `Occupation` type, location, and full skill list
- `ProfilePage` node: added `speakable` spec pointing to `.hero-title`, `.hero-sub`, `.about-text` CSS selectors (signals AI/voice systems which content to read aloud or cite)
- `ProfilePage` node: `dateModified` updated to `2026-04-24`
- `FAQPage` node: expanded from **8 → 14 questions**, adding:
  - "Is Ninad Malvankar the same person as elninad?"
  - "What is ninadmalvankar.com?"
  - "What programming languages does Ninad Malvankar know?"
  - "What company does Ninad Malvankar work for?"
  - "What did Ninad Malvankar build at Upstox?"
  - "Does Ninad Malvankar have a YouTube channel?"

**`robots.txt`**
- Added: `OAI-SearchBot` (OpenAI search), `Claude-SearchBot` (Anthropic), `Amazonbot`, `Google-Extended`
- Added comment pointing crawlers to `llms.txt`

**`sitemap.xml`**
- `<lastmod>` bumped to `2026-04-24`

## Test plan

- [ ] Validate JSON-LD at https://validator.schema.org/ — paste the `<script type="application/ld+json">` block from index.html
- [ ] Verify favicon appears in browser tab after deployment
- [ ] Check `https://ninadmalvankar.com/llms.txt` is accessible
- [ ] Check `https://ninadmalvankar.com/robots.txt` lists all AI bots
- [ ] Run Google Rich Results Test after merge: https://search.google.com/test/rich-results

https://claude.ai/code/session_01Q32Fv3iKKNe4UDr8EFr2FS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q32Fv3iKKNe4UDr8EFr2FS)_