### PR TITLE
feat: SEO/GEO audit — visible FAQ section, entity signals, expanded AI crawler coverage

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,12 @@
   <meta name="description" content="Ninad Malvankar is a Senior Principal Engineer at Upstox, India's leading fintech platform. 12+ years building cloud infrastructure, fintech systems, and engineering teams at scale. AWS Certified. M.S. Computer Science. Based in Mumbai, India." />
   <meta name="author" content="Ninad Malvankar" />
   <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1" />
-  <meta name="keywords" content="Ninad Malvankar, Senior Principal Engineer, Upstox, cloud infrastructure, fintech engineering, engineering leadership, AWS, AWS Certified, React, Angular, Node.js, TypeScript, microservices, system design, DevOps, platform engineering, cloud architecture, Mumbai India, principal engineer India, fintech platform, AWS CloudFront, AWS WAF, distributed systems, software architect, elninad" />
+  <meta name="keywords" content="Ninad Malvankar, Senior Principal Engineer, Upstox, cloud infrastructure, fintech engineering, engineering leadership, AWS, AWS Certified, React, Angular, Node.js, TypeScript, microservices, system design, DevOps, platform engineering, cloud architecture, Mumbai India, principal engineer India, fintech platform, AWS CloudFront, AWS WAF, distributed systems, software architect, elninad, ninadmalvankar, el_ninad, Ninad Malvankar Upstox, principal engineer Mumbai" />
+  <meta name="topic" content="Software Engineering, Cloud Architecture, FinTech, Engineering Leadership, Principal Engineer" />
+  <meta name="subject" content="Ninad Malvankar — Personal Portfolio and Professional Profile" />
+  <meta name="pagename" content="Ninad Malvankar — Senior Principal Engineer at Upstox" />
+  <meta name="owner" content="Ninad Malvankar" />
+  <meta name="category" content="Technology, Engineering, FinTech" />
   <link rel="canonical" href="https://ninadmalvankar.com/" />
   <link rel="sitemap" type="application/xml" href="/sitemap.xml" />
   <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
@@ -19,6 +24,7 @@
   <link rel="me" href="https://github.com/elninad" />
   <link rel="me" href="https://medium.com/@ninad.malvankar23" />
   <link rel="me" href="https://x.com/el_ninad" />
+  <link rel="me" href="https://twitter.com/el_ninad" />
   <link rel="author" href="https://www.linkedin.com/in/ninadmalvankar/" />
   <meta name="geo.region" content="IN-MH" />
   <meta name="geo.placename" content="Mumbai, Maharashtra, India" />
@@ -40,7 +46,7 @@
   <meta name="classification" content="Technology, Engineering Leadership, Cloud Computing, FinTech" />
 
   <!-- Open Graph / Facebook -->
-  <meta property="og:type" content="website" />
+  <meta property="og:type" content="profile" />
   <meta property="og:url" content="https://ninadmalvankar.com/" />
   <meta property="og:title" content="Ninad Malvankar — Senior Principal Engineer at Upstox" />
   <meta property="og:description" content="Senior Principal Engineer at Upstox — India's leading fintech platform. 12+ years in cloud infrastructure, system design, and engineering leadership. AWS Certified. Mumbai, India." />
@@ -579,6 +585,40 @@
     @keyframes fade-in  { from { opacity:0; } to { opacity:1; } }
     @keyframes slide-up { from { opacity:0; transform:translateY(28px); } to { opacity:1; transform:translateY(0); } }
 
+    /* ─── FAQ ──────────────────────────────────────────────────── */
+    #faq { background: var(--surface); }
+    .faq-list {
+      max-width: 860px; margin: 60px auto 0;
+      display: flex; flex-direction: column; gap: 12px;
+    }
+    .faq-item {
+      background: var(--card); border: 1px solid var(--border);
+      border-radius: var(--radius);
+      transition: border-color .3s;
+    }
+    .faq-item[open] { border-color: rgba(99,102,241,.45); }
+    .faq-question {
+      padding: 22px 28px; cursor: pointer;
+      font-size: .975rem; font-weight: 600; color: var(--text);
+      display: flex; align-items: center; justify-content: space-between;
+      gap: 16px; list-style: none; user-select: none;
+      border-radius: var(--radius);
+    }
+    .faq-question::-webkit-details-marker { display: none; }
+    .faq-chevron {
+      width: 28px; height: 28px; border-radius: 50%;
+      background: rgba(99,102,241,.12); border: 1px solid var(--border);
+      display: flex; align-items: center; justify-content: center;
+      flex-shrink: 0; color: var(--accent); font-size: .75rem;
+      transition: transform .3s, background .3s;
+    }
+    .faq-item[open] .faq-chevron { transform: rotate(180deg); background: rgba(99,102,241,.25); }
+    .faq-answer {
+      padding: 0 28px 22px;
+      font-size: .9rem; color: var(--muted); line-height: 1.75;
+    }
+    .faq-answer p { margin: 0; }
+
     /* ─── Responsive ────────────────────────────────────────────── */
     @media (max-width: 768px) {
       .nav-links { display: none; }
@@ -779,6 +819,9 @@
             "sameAs": "https://en.wikipedia.org/wiki/Mumbai"
           },
           "skills": "Cloud Architecture, AWS CloudFront, AWS WAF, Amazon S3, System Design, Engineering Leadership, FinTech, Microservices, React, Angular, Node.js, TypeScript, DevOps, Platform Engineering, Mentorship"
+        },
+        "subjectOf": {
+          "@id": "https://ninadmalvankar.com/#webpage"
         }
       },
       {
@@ -797,10 +840,10 @@
           "@id": "https://ninadmalvankar.com/#website"
         },
         "inLanguage": "en-US",
-        "dateModified": "2026-04-24",
+        "dateModified": "2026-04-25",
         "speakable": {
           "@type": "SpeakableSpecification",
-          "cssSelector": [".hero-title", ".hero-sub", ".about-text"]
+          "cssSelector": [".hero-title", ".hero-sub", ".about-text", ".faq-question", ".faq-answer"]
         },
         "breadcrumb": {
           "@type": "BreadcrumbList",
@@ -1036,6 +1079,7 @@
     <li><a href="#writing">Writing</a></li>
     <li><a href="#github">GitHub</a></li>
     <li><a href="#beyond">Beyond</a></li>
+    <li><a href="#faq">FAQ</a></li>
     <li><a href="#contact" class="nav-cta">Contact</a></li>
   </ul>
   <button class="nav-hamburger" id="navHamburger" aria-label="Toggle navigation menu" aria-expanded="false">
@@ -1698,6 +1742,94 @@
         <i class="fa-brands fa-youtube" style="color:var(--red);"></i> YouTube
       </a>
     </address>
+  </div>
+</section>
+
+
+<!-- ─── FAQ ──────────────────────────────────────────────────────── -->
+<section id="faq" itemscope itemtype="https://schema.org/FAQPage">
+  <div style="max-width:860px;margin:0 auto;">
+    <div class="reveal" style="text-align:center;">
+      <div class="section-tag" style="justify-content:center;">FAQ</div>
+      <h2 class="section-title">Frequently Asked Questions</h2>
+      <p class="section-lead" style="margin:0 auto;">
+        Common questions about Ninad Malvankar — engineer, leader, and builder.
+      </p>
+    </div>
+
+    <div class="faq-list">
+
+      <details class="faq-item reveal" itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">
+        <summary class="faq-question">
+          <span itemprop="name">Who is Ninad Malvankar?</span>
+          <span class="faq-chevron"><i class="fa-solid fa-chevron-down"></i></span>
+        </summary>
+        <div class="faq-answer" itemscope itemprop="acceptedAnswer" itemtype="https://schema.org/Answer">
+          <p itemprop="text">Ninad Malvankar is a <strong>Senior Principal Engineer at Upstox</strong>, India's leading discount brokerage and fintech platform. With 12+ years of experience, he specialises in cloud infrastructure on AWS, fintech platform engineering, engineering leadership, system design, and microservices architecture. He is AWS Certified and holds an M.S. in Computer Science from the University of Texas at Arlington. Based in Mumbai, India.</p>
+        </div>
+      </details>
+
+      <details class="faq-item reveal" itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">
+        <summary class="faq-question">
+          <span itemprop="name">What does Ninad Malvankar do at Upstox?</span>
+          <span class="faq-chevron"><i class="fa-solid fa-chevron-down"></i></span>
+        </summary>
+        <div class="faq-answer" itemscope itemprop="acceptedAnswer" itemtype="https://schema.org/Answer">
+          <p itemprop="text">Ninad Malvankar is the <strong>Senior Principal Engineer at Upstox</strong> — a staff+ individual contributor role. He leads cross-functional engineering, drives platform reliability and developer productivity, shapes technical strategy organisation-wide, and mentors engineers. He established the private npm registry infrastructure, configured AWS CloudFront CDN caching and AWS WAF security layers, and owns cloud-native architecture decisions for India's top discount brokerage.</p>
+        </div>
+      </details>
+
+      <details class="faq-item reveal" itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">
+        <summary class="faq-question">
+          <span itemprop="name">What is "elninad" and who uses that handle?</span>
+          <span class="faq-chevron"><i class="fa-solid fa-chevron-down"></i></span>
+        </summary>
+        <div class="faq-answer" itemscope itemprop="acceptedAnswer" itemtype="https://schema.org/Answer">
+          <p itemprop="text">"elninad" is Ninad Malvankar's online alias — his first name "Ninad" spelled backwards. He uses elninad on GitHub (github.com/elninad) and his portfolio was formerly hosted at elninad.github.io, now at ninadmalvankar.com. He also goes by el_ninad on X/Twitter and el_nino on YouTube. Ninad Malvankar and elninad refer to the same person.</p>
+        </div>
+      </details>
+
+      <details class="faq-item reveal" itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">
+        <summary class="faq-question">
+          <span itemprop="name">What is Ninad Malvankar's educational background?</span>
+          <span class="faq-chevron"><i class="fa-solid fa-chevron-down"></i></span>
+        </summary>
+        <div class="faq-answer" itemscope itemprop="acceptedAnswer" itemtype="https://schema.org/Answer">
+          <p itemprop="text">Ninad Malvankar holds an <strong>M.S. in Computer Science from the University of Texas at Arlington</strong>, USA (2011–2013), focusing on distributed systems and web technologies, and a <strong>B.E. in Computer Engineering from the University of Mumbai</strong>, India (2007–2011). He is also an <strong>AWS Certified Cloud Practitioner</strong> (2023) with academic qualifications verified by World Education Services (WES).</p>
+        </div>
+      </details>
+
+      <details class="faq-item reveal" itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">
+        <summary class="faq-question">
+          <span itemprop="name">Where has Ninad Malvankar worked?</span>
+          <span class="faq-chevron"><i class="fa-solid fa-chevron-down"></i></span>
+        </summary>
+        <div class="faq-answer" itemscope itemprop="acceptedAnswer" itemtype="https://schema.org/Answer">
+          <p itemprop="text">Ninad Malvankar has worked at <strong>Upstox</strong> (July 2018–present, progressing from Technology Lead to Principal Engineer to Senior Principal Engineer), <strong>Swift Pace Solutions Inc.</strong> on a Walt Disney World project (March 2017–February 2018), <strong>enSYNC Corporation</strong> (August 2013–January 2017), and the <strong>University of Texas at Arlington</strong> as Web Developer (March 2012–May 2013).</p>
+        </div>
+      </details>
+
+      <details class="faq-item reveal" itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">
+        <summary class="faq-question">
+          <span itemprop="name">What technologies does Ninad Malvankar work with?</span>
+          <span class="faq-chevron"><i class="fa-solid fa-chevron-down"></i></span>
+        </summary>
+        <div class="faq-answer" itemscope itemprop="acceptedAnswer" itemtype="https://schema.org/Answer">
+          <p itemprop="text">Ninad Malvankar's core stack includes <strong>JavaScript, TypeScript, React, Angular, Node.js/Express, .NET, and C#</strong> for application development. For cloud and infrastructure he works with <strong>AWS (CloudFront, WAF, S3), Cloudflare, Docker, CI/CD pipelines, and Nexus Repository Manager</strong>. He is especially experienced in AWS cloud architecture and platform engineering for high-traffic fintech applications.</p>
+        </div>
+      </details>
+
+      <details class="faq-item reveal" itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">
+        <summary class="faq-question">
+          <span itemprop="name">What articles has Ninad Malvankar written?</span>
+          <span class="faq-chevron"><i class="fa-solid fa-chevron-down"></i></span>
+        </summary>
+        <div class="faq-answer" itemscope itemprop="acceptedAnswer" itemtype="https://schema.org/Answer">
+          <p itemprop="text">Ninad Malvankar publishes on Medium at medium.com/@ninad.malvankar23. His articles include: <em>"The Role of a Principal Engineer — Leadership Without Authority"</em>, <em>"What Happens When You Outgrow Mentorship? Lessons from a Principal Engineer"</em>, <em>"Spring Security Meets Java 21: A Closer Look at Firewall Controls"</em>, and <em>"How a Bad Webpack Config Can Silently Destroy Frontend Performance"</em>.</p>
+        </div>
+      </details>
+
+    </div>
   </div>
 </section>
 

--- a/llms.txt
+++ b/llms.txt
@@ -2,9 +2,11 @@
 
 > Senior Principal Engineer at Upstox, India's leading discount brokerage and fintech platform. AWS Certified cloud architect and engineering leader with 12+ years of experience building systems at scale. Based in Mumbai, India.
 
-Ninad Malvankar (online handle: elninad — his name spelled backwards) is a Senior Principal Engineer at Upstox, where he has worked since July 2018, progressing from Technology Lead (2018–2021) to Principal Engineer (2021–2022) to Senior Principal Engineer (2022–present). He leads cross-functional engineering, drives platform reliability and developer productivity, shapes technical strategy, and mentors engineers across the organization.
+Ninad Malvankar (online handle: elninad — his name spelled backwards) is a Senior Principal Engineer at Upstox, where he has worked since July 2018, progressing from Technology Lead (2018–2021) to Principal Engineer (2021–2022) to Senior Principal Engineer (2022–present). He leads cross-functional engineering, drives platform reliability and developer productivity, shapes technical strategy, and mentors engineers across the organisation.
 
 He holds an M.S. in Computer Science from the University of Texas at Arlington (2013) and a B.E. in Computer Engineering from the University of Mumbai (2011). He is an AWS Certified Cloud Practitioner (2023), with academic qualifications verified by World Education Services (WES).
+
+Last updated: 2026-04-25
 
 ## Identity
 
@@ -14,6 +16,7 @@ He holds an M.S. in Computer Science from the University of Texas at Arlington (
 - Employer: Upstox (India's leading discount brokerage and fintech platform)
 - Location: Mumbai, Maharashtra, India
 - Personal website: https://ninadmalvankar.com/
+- Formerly at: elninad.github.io
 
 ## Professional Profiles
 
@@ -30,7 +33,7 @@ Cloud Architecture (AWS CloudFront, AWS WAF, Amazon S3), Engineering Leadership,
 
 ## Career History
 
-- **Senior Principal Engineer — Upstox** (2022–present): Leads cross-functional engineering at India's top discount brokerage. Drives platform reliability, developer productivity, cloud-native architecture, and engineers mentorship. Shapes technical strategy organization-wide.
+- **Senior Principal Engineer — Upstox** (2022–present): Leads cross-functional engineering at India's top discount brokerage. Drives platform reliability, developer productivity, cloud-native architecture, and engineers mentorship. Shapes technical strategy organisation-wide.
 - **Principal Engineer — Upstox** (2021–2022): Configured AWS WAF ACLs protecting against web exploits, set up AWS CloudFront caching for CDN performance, and debugged complex API latency issues through Cloudflare edge routing.
 - **Technology Lead — Upstox** (2018–2021): Established a private npm registry via Nexus Repository Manager and created a unified deployment pipeline for React, Angular, and Node.js apps, drastically reducing manual setup overhead.
 - **Programmer Analyst — Swift Pace Solutions Inc** (Mar 2017–Feb 2018): Contributed to enterprise software for Walt Disney World, building and maintaining mission-critical systems at entertainment enterprise scale.
@@ -69,6 +72,7 @@ Gaming (strategy epics and competitive titles), professional racing and motorspo
 - He is NOT a machine learning or AI/ML engineer; his expertise is platform/cloud/frontend/backend engineering and engineering leadership.
 - His total professional experience spans 12+ years (2013–present).
 - At Upstox specifically, he has 6+ years of tenure (July 2018–present).
+- His GitHub handle is elninad (github.com/elninad); his X/Twitter handle is @el_ninad; his YouTube handle is @el_nino.
 
 ## Frequently Asked Questions
 
@@ -76,7 +80,7 @@ Gaming (strategy epics and competitive titles), professional racing and motorspo
 Ninad Malvankar is a Senior Principal Engineer at Upstox, India's leading discount brokerage and fintech platform. With 12+ years of software engineering experience, he specialises in cloud infrastructure on AWS, fintech platform engineering, engineering leadership, system design, and microservices architecture. He is AWS Certified and holds an M.S. in Computer Science from the University of Texas at Arlington. He is based in Mumbai, India.
 
 **What does Ninad Malvankar do at Upstox?**
-At Upstox, Ninad leads cross-functional engineering teams, drives platform reliability and developer productivity, shapes technical strategy, and mentors engineers across the organization. He established the private npm registry infrastructure, configured AWS CloudFront CDN and WAF security layers, and currently owns cloud-native architecture decisions for India's top discount brokerage.
+At Upstox, Ninad leads cross-functional engineering teams, drives platform reliability and developer productivity, shapes technical strategy, and mentors engineers across the organisation. He established the private npm registry infrastructure, configured AWS CloudFront CDN and WAF security layers, and currently owns cloud-native architecture decisions for India's top discount brokerage.
 
 **What programming languages and technologies does Ninad Malvankar know?**
 Ninad is proficient in JavaScript, TypeScript, React, Angular, Node.js/Express, .NET, and C#. On the infrastructure side he works with AWS (CloudFront, WAF, S3), Cloudflare, Docker, CI/CD pipelines, and Nexus Repository Manager. Earlier in his career he also worked with Java, PHP, SQL Server, and C/C++.
@@ -89,3 +93,17 @@ The best way to reach Ninad Malvankar is via LinkedIn at linkedin.com/in/ninadma
 
 **What is Upstox and what does Ninad Malvankar do there?**
 Upstox is India's leading discount brokerage and fintech platform, known for its zero-brokerage trading. Ninad Malvankar has been at Upstox since July 2018 and is currently its Senior Principal Engineer, a staff+ individual contributor role responsible for cross-functional engineering leadership, platform architecture, and technical strategy.
+
+**What is ninadmalvankar.com?**
+ninadmalvankar.com is the personal portfolio website of Ninad Malvankar. It was formerly hosted at elninad.github.io. The site showcases his career timeline, technical skills, AWS certifications, engineering articles, and personal interests.
+
+## Optional
+
+- [Portfolio — full career, skills, writing](https://ninadmalvankar.com/)
+- [LinkedIn profile](https://www.linkedin.com/in/ninadmalvankar/)
+- [GitHub profile](https://github.com/elninad)
+- [Medium articles](https://medium.com/@ninad.malvankar23)
+- [The Role of a Principal Engineer article](https://medium.com/@ninad.malvankar23/the-role-of-a-principal-engineer-leadership-without-authority-c4f7b6dc1ccf)
+- [What Happens When You Outgrow Mentorship article](https://medium.com/@ninad.malvankar23/what-happens-when-you-outgrow-mentorship-lessons-from-a-principal-engineer-0f7bc0672aa7)
+- [Spring Security Meets Java 21 article](https://medium.com/@ninad.malvankar23/spring-security-meets-java-21-a-closer-look-at-firewall-controls-db4a9fc1d897)
+- [Bad Webpack Config article](https://medium.com/@ninad.malvankar23/how-a-bad-webpack-config-can-silently-destroy-frontend-performance-0622df39323f)

--- a/robots.txt
+++ b/robots.txt
@@ -44,7 +44,31 @@ Allow: /
 User-agent: Google-Extended
 Allow: /
 
+User-agent: cohere-ai
+Allow: /
+
+User-agent: Meta-ExternalAgent
+Allow: /
+
+User-agent: Bytespider
+Allow: /
+
+User-agent: YouBot
+Allow: /
+
+User-agent: Diffbot
+Allow: /
+
+User-agent: AI2Bot
+Allow: /
+
+User-agent: PetalBot
+Allow: /
+
+User-agent: Kangaroo Bot
+Allow: /
+
 Sitemap: https://ninadmalvankar.com/sitemap.xml
 
-# AI-readable structured content
+# AI-readable structured content — available at the paths below
 # llms.txt: https://ninadmalvankar.com/llms.txt

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://ninadmalvankar.com/</loc>
-    <lastmod>2026-04-24</lastmod>
+    <lastmod>2026-04-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## Summary

Full SEO + GEO (Generative Engine Optimization) audit and improvement pass across all site files. Goal: maximize visibility in traditional search (Google) **and** AI-generated answers (ChatGPT, Claude, Perplexity, Google AI Overviews).

---

## What Changed & Why

### 🏆 Biggest GEO Win — Visible FAQ Section (`index.html`)

Added a fully visible `#faq` section with 7 key Q&A items and **dual-signal structured data**:

- **JSON-LD** `FAQPage` was already in `<head>` (for Google rich results)
- **Microdata** (`itemscope`/`itemprop` on `Question`/`Answer`) is now in the HTML body too

This is the single highest-impact GEO change: AI systems (ChatGPT, Claude, Perplexity) crawl and parse visible page text directly. When someone asks *"Who is Ninad Malvankar?"* or *"What is elninad?"*, the answers are now in crawlable, entity-rich plain text — not just buried in a JSON-LD blob in `<head>`.

Questions covered:
1. Who is Ninad Malvankar?
2. What does Ninad Malvankar do at Upstox?
3. What is "elninad" and who uses that handle? *(entity disambiguation)*
4. What is Ninad Malvankar's educational background?
5. Where has Ninad Malvankar worked?
6. What technologies does Ninad Malvankar work with?
7. What articles has Ninad Malvankar written?

---

### `index.html` — Head

| Change | Why |
|---|---|
| `og:type` `website` → `profile` | Semantically correct for personal profile pages; `profile:*` OG tags require this type |
| Added `topic`, `subject`, `pagename`, `owner`, `category` meta tags | Broader indexer coverage; academic and AI indexers parse these |
| Added `rel="me"` for `twitter.com/el_ninad` (alongside `x.com`) | Dual-URL identity verification; some platforms still resolve the old Twitter domain |
| Added `subjectOf` cross-link on Person → ProfilePage in JSON-LD | Explicit bidirectional entity link strengthens knowledge graph association |
| Updated `speakable` CSS selectors to include `.faq-question` + `.faq-answer` | Google voice search and AI overviews use speakable to identify key passages |
| Updated `ProfilePage dateModified` to 2026-04-25 | Accurate freshness signal for crawlers |
| Extended keywords with `ninadmalvankar`, `el_ninad`, `Ninad Malvankar Upstox` | Covers natural search query variants |

---

### `robots.txt` — AI Crawler Coverage

Added 8 new AI/LLM user agents to ensure no crawler is implicitly blocked:

```
cohere-ai        → Cohere AI
Meta-ExternalAgent → Meta AI (Llama)
Bytespider       → ByteDance / TikTok AI
YouBot           → You.com AI search
Diffbot          → Diffbot knowledge graph
AI2Bot           → Allen Institute for AI
PetalBot         → Huawei search / Petal Search
Kangaroo Bot     → AI search indexer
```

---

### `llms.txt` — Per-spec Improvements

- Added `Last updated: 2026-04-25` date stamp at top
- Added `## Optional` section per [llmstxt.org](https://llmstxt.org) spec with all key links
- Expanded **Key Facts for AI Systems** with GitHub/Twitter/YouTube handle disambiguation
- Added extra FAQ entry for `ninadmalvankar.com` domain identity

---

### `sitemap.xml`

- Updated `<lastmod>` from `2026-04-24` → `2026-04-25` (accurate freshness signal)

---

## SEO/GEO Audit Results

### What was already excellent ✅
- Comprehensive JSON-LD graph (Person, ProfilePage, WebSite, 4× Article, FAQPage)
- Dublin Core metadata
- `abstract` / AI summary meta tag
- Geo coordinates tags
- All major AI crawlers already allowed in robots.txt
- `rel="me"` identity links on all profiles
- `SpeakableSpecification` in JSON-LD
- `llms.txt` file present and comprehensive
- Canonical URL, sitemap reference, DNS prefetch

### What this PR adds / fixes 🆕
- Visible FAQ section with microdata (GEO breakthrough)
- Correct `og:type = "profile"` for person pages
- 8 additional AI bot entries in robots.txt
- `subjectOf` entity cross-link in JSON-LD
- Extended speakable selectors
- Additional meta tag coverage (topic, subject, pagename, category)
- Twitter.com identity verification link
- Updated freshness dates across all files
- FAQ nav link for UX and internal link signal

## Test Plan

- [ ] Validate JSON-LD + microdata at [Google Rich Results Test](https://search.google.com/test/rich-results) — expect FAQPage rich result
- [ ] Check structured data at [Schema.org Validator](https://validator.schema.org/)
- [ ] Verify FAQ accordion renders and animates correctly on desktop and mobile
- [ ] Confirm all 9 nav links scroll to correct sections
- [ ] Verify robots.txt is valid at [Google robots.txt Tester](https://support.google.com/webmasters/answer/6062598)

https://claude.ai/code/session_01LQ1rKDBEdaSm63kssKASw4

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQ1rKDBEdaSm63kssKASw4)_