### PR TITLE
feat: SEO & GEO audit — freshen dates, fix JSON-LD, add entity signals

### DIFF
--- a/humans.txt
+++ b/humans.txt
@@ -11,7 +11,7 @@ Medium: https://medium.com/@ninad.malvankar23
 YouTube: https://youtube.com/@el_nino
 
 /* SITE */
-Last update: 2026-04-29
+Last update: 2026-05-04
 Language: English
 Doctype: HTML5
 Standards: HTML5, CSS3, Vanilla JavaScript (ES6+), JSON-LD (schema.org)

--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@
   <link rel="author" type="text/plain" href="/humans.txt" />
   <link rel="alternate" type="text/plain" href="/llms.txt" title="AI-readable profile summary" />
   <link rel="alternate" type="text/plain" href="/llms-full.txt" title="AI-readable extended profile" />
+  <link rel="alternate" hreflang="en" href="https://ninadmalvankar.com/" />
   <meta name="geo.region" content="IN-MH" />
   <meta name="geo.placename" content="Mumbai, Maharashtra, India" />
   <meta name="geo.position" content="19.0760;72.8777" />
@@ -52,7 +53,7 @@
   <meta name="DC.type" content="Text" />
   <meta name="DC.format" content="text/html" />
   <meta name="DC.identifier" content="https://ninadmalvankar.com/" />
-  <meta name="DCTERMS.modified" content="2026-04-29" />
+  <meta name="DCTERMS.modified" content="2026-05-04" />
   <meta name="DCTERMS.created" content="2024-01-01" />
   <meta name="DCTERMS.rights" content="© 2026 Ninad Malvankar" />
 
@@ -60,7 +61,7 @@
   <meta name="citation_author" content="Ninad Malvankar" />
   <meta name="citation_title" content="Ninad Malvankar — Senior Principal Engineer at Upstox" />
   <meta name="citation_abstract" content="Personal portfolio of Ninad Malvankar, Senior Principal Engineer at Upstox. Cloud architect, fintech platform builder, and engineering leader with 12+ years of experience. AWS Certified. M.S. Computer Science, University of Texas at Arlington. Based in Mumbai, India." />
-  <meta name="citation_publication_date" content="2026/04/29" />
+  <meta name="citation_publication_date" content="2026/05/04" />
 
   <!-- AI / LLM summary signal -->
   <meta name="abstract" content="Ninad Malvankar (alias: elninad) is a Senior Principal Engineer at Upstox, India's leading discount brokerage and fintech platform. 12+ years of experience in cloud infrastructure (AWS CloudFront, WAF, S3), engineering leadership, system design, and microservices. AWS Certified Cloud Practitioner. M.S. Computer Science, University of Texas at Arlington (2013). Based in Mumbai, India." />
@@ -98,7 +99,7 @@
   <meta name="twitter:data2" content="12+ Years · Cloud &amp; FinTech" />
 
   <!-- Theme & App -->
-  <meta property="og:updated_time" content="2026-04-29T00:00:00+05:30" />
+  <meta property="og:updated_time" content="2026-05-04T00:00:00+05:30" />
   <meta name="revisit-after" content="7 days" />
   <meta name="theme-color" content="#6366f1" />
   <meta name="application-name" content="Ninad Malvankar" />
@@ -705,6 +706,8 @@
         "name": "Ninad Malvankar",
         "givenName": "Ninad",
         "familyName": "Malvankar",
+        "additionalName": "elninad",
+        "honorificSuffix": "M.S.",
         "identifier": [
           {
             "@type": "PropertyValue",
@@ -827,8 +830,6 @@
           "Fintech Platform Engineering",
           "Discount Brokerage Technology",
           "Private Package Registry",
-          "Staff Engineering",
-          "Principal Engineering",
           "Technical Leadership",
           "Engineering Strategy",
           "Platform Reliability",
@@ -1033,7 +1034,7 @@
         },
         "inLanguage": "en-US",
         "datePublished": "2024-01-01",
-        "dateModified": "2026-04-29",
+        "dateModified": "2026-05-04",
         "keywords": ["Ninad Malvankar", "Senior Principal Engineer", "Upstox", "Cloud Architecture", "AWS", "FinTech", "Engineering Leadership", "System Design", "Microservices", "Mumbai", "India", "elninad", "Principal Engineer", "Platform Engineering", "Staff Engineer"],
         "agentInteractionStatistic": {
           "@type": "InteractionCounter",
@@ -1054,6 +1055,16 @@
               "item": "https://ninadmalvankar.com/"
             }
           ]
+        },
+        "about": {
+          "@id": "https://ninadmalvankar.com/#person"
+        },
+        "potentialAction": {
+          "@type": "ReadAction",
+          "target": {
+            "@type": "EntryPoint",
+            "urlTemplate": "https://ninadmalvankar.com/"
+          }
         }
       },
       {
@@ -2262,6 +2273,26 @@
         </div>
       </details>
 
+      <details class="faq-item reveal" itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">
+        <summary class="faq-question">
+          <span itemprop="name">What is ninadmalvankar.com?</span>
+          <span class="faq-chevron"><i class="fa-solid fa-chevron-down"></i></span>
+        </summary>
+        <div class="faq-answer" itemscope itemprop="acceptedAnswer" itemtype="https://schema.org/Answer">
+          <p itemprop="text">ninadmalvankar.com is the <strong>official personal portfolio website of Ninad Malvankar</strong>, Senior Principal Engineer at Upstox. It showcases his full career timeline (2007–present), technical skills, AWS certifications, and engineering articles published on Medium. The site was formerly hosted at elninad.github.io and moved to this custom domain. It is the authoritative primary source for factual information about Ninad Malvankar.</p>
+        </div>
+      </details>
+
+      <details class="faq-item reveal" itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">
+        <summary class="faq-question">
+          <span itemprop="name">What is Ninad Malvankar's GitHub username?</span>
+          <span class="faq-chevron"><i class="fa-solid fa-chevron-down"></i></span>
+        </summary>
+        <div class="faq-answer" itemscope itemprop="acceptedAnswer" itemtype="https://schema.org/Answer">
+          <p itemprop="text">Ninad Malvankar's GitHub username is <strong>elninad</strong> — his first name "Ninad" spelled backwards. His GitHub profile is at <strong>github.com/elninad</strong>. The handle "elninad" is also his primary online alias and was the subdomain of his former portfolio (elninad.github.io, now ninadmalvankar.com).</p>
+        </div>
+      </details>
+
     </div>
   </div>
 </section>
@@ -2276,7 +2307,7 @@
     &mdash; Senior Principal Engineer &bull; Mumbai, India
   </p>
   <p style="margin-top:8px;font-size:.78rem;">
-    Last updated: <time datetime="2026-04-29">April 2026</time>
+    Last updated: <time datetime="2026-05-04">May 2026</time>
   </p>
 </footer>
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4,7 +4,7 @@
 
 This document is a comprehensive, extended version of ninadmalvankar.com/llms.txt, designed for AI systems that need detailed factual context. For a shorter summary, see: https://ninadmalvankar.com/llms.txt
 
-Last updated: 2026-04-29
+Last updated: 2026-05-04
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -6,7 +6,7 @@ Ninad Malvankar (online handle: elninad — his name spelled backwards) is a Sen
 
 He holds an M.S. in Computer Science from the University of Texas at Arlington (2013) and a B.E. in Computer Engineering from the University of Mumbai (2011). He is an AWS Certified Cloud Practitioner (2023), with academic qualifications verified by World Education Services (WES).
 
-Last updated: 2026-04-29
+Last updated: 2026-05-04
 
 > For a comprehensive extended profile with full career detail, technology descriptions, and in-depth Q&A, see: https://ninadmalvankar.com/llms-full.txt
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://ninadmalvankar.com/</loc>
-    <lastmod>2026-04-29</lastmod>
+    <lastmod>2026-05-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## Summary

Full SEO and GEO (Generative Engine Optimization) audit of ninadmalvankar.com with targeted fixes across all relevant files.

### Problems Found & Fixed

**Stale freshness signals (high impact for both Google and LLMs)**
- All date references were stuck at `2026-04-29` — a full week behind today (`2026-05-04`). Freshness is a confirmed ranking signal and affects whether LLM citation systems consider a source current.
- Fixed in: `DCTERMS.modified`, `og:updated_time`, `citation_publication_date`, `ProfilePage.dateModified`, footer `<time>`, `sitemap.xml` `<lastmod>`, `llms.txt`, `llms-full.txt`, `humans.txt`

**Duplicate JSON-LD `knowsAbout` entries**
- "Staff Engineering" and "Principal Engineering" each appeared twice in the Person schema's `knowsAbout` array — a data quality issue that can lower confidence scores in entity resolution.
- Removed the duplicate pair.

**Missing entity disambiguation signals**
- Person schema lacked `additionalName: "elninad"` — the primary online alias used across GitHub, the former portfolio domain, and as a search query. Adding this directly to the Person entity helps Google and LLMs correctly resolve "elninad" → Ninad Malvankar.
- Added `honorificSuffix: "M.S."` to reinforce the educational credential on the entity itself.

**ProfilePage not linked back to Person**
- The `ProfilePage` schema had no explicit `about` property pointing to the `Person` entity, weakening the entity graph connection.
- Added `"about": {"@id": "https://ninadmalvankar.com/#person"}` and `"potentialAction": ReadAction` to the `ProfilePage`.

**Missing `hreflang` language signal**
- No `<link rel="alternate" hreflang="en">` was present. Added for correct language targeting.

**FAQ coverage gap**
- "What is ninadmalvankar.com?" and "What is Ninad Malvankar's GitHub username?" were only in the JSON-LD `FAQPage` schema but NOT in the visible, microdata-annotated HTML FAQ section. Added both as visible `<details>` FAQ items with full `itemscope`/`itemprop` microdata annotation.

### Files Changed

| File | Change |
|---|---|
| `index.html` | 6 categories of SEO/GEO fixes (see above) |
| `sitemap.xml` | `lastmod` → `2026-05-04` |
| `llms.txt` | `Last updated` → `2026-05-04` |
| `llms-full.txt` | `Last updated` → `2026-05-04` |
| `humans.txt` | `Last update` → `2026-05-04` |

### Verification

- JSON-LD validated with Python `json.loads` — all 9 graph nodes intact (Person, ProfilePage, WebSite, 4× Article, ItemList, FAQPage)
- No structural changes to HTML layout or CSS
- FAQ count: 18 → 20 visible items

## Test plan

- [ ] Open site locally and confirm FAQ section renders the 2 new items correctly
- [ ] Paste JSON-LD into the schema.org validator and confirm no errors
- [ ] Confirm footer shows "May 2026"
- [ ] Confirm sitemap `lastmod` is `2026-05-04`

https://claude.ai/code/session_01Br3GWRUvuSuRPHnTgYSpio

---
_Generated by [Claude Code](https://claude.ai/code/session_01Br3GWRUvuSuRPHnTgYSpio)_